### PR TITLE
Install test option files to share directory and fix test environment

### DIFF
--- a/k4Gen/CMakeLists.txt
+++ b/k4Gen/CMakeLists.txt
@@ -26,28 +26,15 @@ install(TARGETS k4Gen
 
 include(CTest)
 
-get_target_property(k4fwcore_lib k4FWCore::k4FWCore LOCATION)
-get_filename_component(k4fwcore_loc ${k4fwcore_lib} DIRECTORY)
-
-get_target_property(edm4hep_lib EDM4HEP::edm4hepDict LOCATION)
-get_filename_component(edm4hep_loc ${edm4hep_lib} DIRECTORY)
-
-get_target_property(root_lib ROOT::Core LOCATION)
-get_filename_component(root_loc ${root_lib} DIRECTORY)
-
-get_target_property(podio_lib podio::podio LOCATION)
-get_filename_component(podio_loc ${podio_lib} DIRECTORY)
-
 
 function(set_test_env _testname)
-  set_property(TEST ${_testname} APPEND PROPERTY ENVIRONMENT "ROOT_INCLUDE_PATH=${podio_loc}/../include/podio:${edm4hep_loc}/../include:$ENV{ROOT_INCLUDE_PATH}")
-  set_property(TEST ${_testname} APPEND PROPERTY ENVIRONMENT "LD_LIBRARY_PATH=${CMAKE_BINARY_DIR}:${CMAKE_BINARY_DIR}/${CMAKE_PROJECT_NAME}:${root_loc}:${k4fwcore_loc}:${edm4hep_loc}:${podio_loc}:$ENV{LD_LIBRARY_PATH}")
-  set_property(TEST ${_testname} APPEND PROPERTY ENVIRONMENT "PYTHONPATH=${CMAKE_BINARY_DIR}/${CMAKE_PROJECT_NAME}/genConf:${k4fwcore_loc}/../python:$ENV{PYTHONPATH}")
-  set_property(TEST ${_testname} APPEND PROPERTY ENVIRONMENT "PATH=${k4fwcore_loc}/../bin:$ENV{PATH}")
-  set_property(TEST ${_testname} APPEND PROPERTY ENVIRONMENT "K4GEN=${CMAKE_CURRENT_LIST_DIR}/")
+  set_property(TEST ${_testname} APPEND PROPERTY ENVIRONMENT
+    LD_LIBRARY_PATH=${CMAKE_BINARY_DIR}:$<TARGET_FILE_DIR:k4Gen>:$<TARGET_FILE_DIR:ROOT::Core>:$<TARGET_FILE_DIR:k4FWCore::k4FWCore>:$<TARGET_FILE_DIR:EDM4HEP::edm4hep>:$<TARGET_FILE_DIR:podio::podio>:$ENV{LD_LIBRARY_PATH}
+    PYTHONPATH=${CMAKE_BINARY_DIR}/${CMAKE_PROJECT_NAME}/genConfDir:$<TARGET_FILE_DIR:k4FWCore::k4FWCore>/../python:$ENV{PYTHONPATH}
+    PATH=$<TARGET_FILE_DIR:k4FWCore::k4FWCore>/../bin:$ENV{PATH}
+    K4GEN=${CMAKE_CURRENT_LIST_DIR}/
+    )
 endfunction()
-
-
 
 
 add_test(NAME ParticleGun

--- a/k4Gen/CMakeLists.txt
+++ b/k4Gen/CMakeLists.txt
@@ -6,12 +6,11 @@ find_package(HepMC)
 find_package(Pythia8 COMPONENTS pythia8 pythia8tohepmc)
 find_package(HepPDT)
 find_package(EvtGen)
-find_package(Gaudi)
 
 file(GLOB k4gen_plugin_sources src/components/*.cpp)
 gaudi_add_module(k4Gen
                  SOURCES ${k4gen_plugin_sources}
-                 LINK Gaudi::GaudiKernel HepMC Gaudi::GaudiAlgLib k4FWCore::k4FWCore k4FWCore::k4FWCorePlugins HepPDT ${EVTGEN_LIBRARIES} EDM4HEP::edm4hep EDM4HEP::edm4hepDict)
+                 LINK Gaudi::GaudiKernel ${HEPMC_LIBRARIES} Gaudi::GaudiAlgLib k4FWCore::k4FWCore k4FWCore::k4FWCorePlugins ${HEPPDT_LIBRARIES} ${EVTGEN_LIBRARIES} EDM4HEP::edm4hep EDM4HEP::edm4hepDict)
 
 target_include_directories(k4Gen PUBLIC ${PYTHIA8_INCLUDE_DIRS}
   $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/include>

--- a/k4Gen/CMakeLists.txt
+++ b/k4Gen/CMakeLists.txt
@@ -64,4 +64,8 @@ add_test(NAME Pythia8Default
               )
 set_test_env(Pythia8Default)
 
-
+#--- Install the example options to the directory where the spack installation
+#--- points the $K4GEN environment variable
+install(DIRECTORY ${CMAKE_CURRENT_LIST_DIR}/options
+  DESTINATION ${CMAKE_INSTALL_DATADIR}/${CMAKE_PROJECT_NAME}/examples
+  PATTERN "__init__.py" EXCLUDE)

--- a/k4Gen/CMakeLists.txt
+++ b/k4Gen/CMakeLists.txt
@@ -26,11 +26,17 @@ install(TARGETS k4Gen
 
 include(CTest)
 
+#--- The genConf directory has been renamed to genConfDir in Gaudi 35r1
+#--- See https://gitlab.cern.ch/gaudi/Gaudi/-/merge_requests/1158
+set(GAUDI_GENCONF_DIR "genConfDir")
+if (${Gaudi_VERSION} VERSION_LESS 35.1)
+  set(GAUDI_GENCONF_DIR "genConf")
+endif()
 
 function(set_test_env _testname)
   set_property(TEST ${_testname} APPEND PROPERTY ENVIRONMENT
     LD_LIBRARY_PATH=${CMAKE_BINARY_DIR}:$<TARGET_FILE_DIR:k4Gen>:$<TARGET_FILE_DIR:ROOT::Core>:$<TARGET_FILE_DIR:k4FWCore::k4FWCore>:$<TARGET_FILE_DIR:EDM4HEP::edm4hep>:$<TARGET_FILE_DIR:podio::podio>:$ENV{LD_LIBRARY_PATH}
-    PYTHONPATH=${CMAKE_BINARY_DIR}/${CMAKE_PROJECT_NAME}/genConfDir:$<TARGET_FILE_DIR:k4FWCore::k4FWCore>/../python:$ENV{PYTHONPATH}
+    PYTHONPATH=${CMAKE_BINARY_DIR}/${CMAKE_PROJECT_NAME}/${GAUDI_GENCONF_DIR}:$<TARGET_FILE_DIR:k4FWCore::k4FWCore>/../python:$ENV{PYTHONPATH}
     PATH=$<TARGET_FILE_DIR:k4FWCore::k4FWCore>/../bin:$ENV{PATH}
     K4GEN=${CMAKE_CURRENT_LIST_DIR}/
     )


### PR DESCRIPTION
- Install the test option files to `<prefix>/share/k4Gen/examples/options` (i.e. `$K4GEN/examples/options` in the spack key4hep setup script).
- Fix the test environment by replacing `genConf` with `genConfDir` (see [Gaudi!1158](https://gitlab.cern.ch/gaudi/Gaudi/-/merge_requests/1158)), and use cmake generator expressions to get the necessary paths
- Use `HEPMC_LIBRARIES` and `HEPPDT_LIBRARIES` in `k4Gen` module definition, since the find modules for these do not define targets.

The last point was necessary for me to even build successfully locally.