### PR TITLE
Install necessary pythia cmd for running example

### DIFF
--- a/k4Gen/CMakeLists.txt
+++ b/k4Gen/CMakeLists.txt
@@ -61,3 +61,6 @@ set_test_env(Pythia8Default)
 install(DIRECTORY ${CMAKE_CURRENT_LIST_DIR}/options
   DESTINATION ${CMAKE_INSTALL_DATADIR}/${CMAKE_PROJECT_NAME}/examples
   PATTERN "__init__.py" EXCLUDE)
+
+install(FILES ${CMAKE_CURRENT_LIST_DIR}/data/Pythia_standard.cmd
+  DESTINATION ${CMAKE_INSTALL_DATADIR}/${CMAKE_PROJECT_NAME}/data)


### PR DESCRIPTION
Missed this in #1, but necessary to run
```sh
k4run $K4GEN/examples/options/pythia.py
```

This only installs the one pythia cmd that is necessary to run the `pythia.py` example in an environment where `K4GEN` is set like in the stack. Should we install all data files already now, or do we just update the installed files as we go along?