### PR TITLE
Add production vertex information to HepMCToEDMConverter

### DIFF
--- a/k4Gen/src/components/FlatSmearVertex.h
+++ b/k4Gen/src/components/FlatSmearVertex.h
@@ -52,7 +52,7 @@ private:
   /// Direction of the beam to take into account TOF vs nominal IP8, can have
   /// only values -1 or 1, or 0 to switch off the TOF and set time of
   /// interaction to zero (default = 1, as for beam 1)
-  Gaudi::Property<int> m_zDir{"beamDirection", 1, "Direction of the beam, possible values: -1, 1 or 0"};
+  Gaudi::Property<int> m_zDir{this, "beamDirection", 1, "Direction of the beam, possible values: -1, 1 or 0"};
 
   /// Flat random number generator
   Rndm::Numbers m_flatDist;

--- a/k4Gen/src/components/HepMCToEDMConverter.cpp
+++ b/k4Gen/src/components/HepMCToEDMConverter.cpp
@@ -6,18 +6,27 @@
 DECLARE_COMPONENT(HepMCToEDMConverter)
 
 
-edm4hep::MCParticle convert(HepMC::GenParticle* hepmcParticle) {
-    edm4hep::MCParticle edm_particle;
-    edm_particle.setPDG(hepmcParticle->pdg_id());
-    edm_particle.setGeneratorStatus(hepmcParticle->status());
-    // look up charge from pdg_id
-    HepPDT::ParticleID particleID(hepmcParticle->pdg_id());
-    edm_particle.setCharge(particleID.charge());
-    //  convert momentum
-    auto p = hepmcParticle->momentum();
-    edm_particle.setMomentum( {float(p.px()), float(p.py()), float(p.pz())} );
-    return edm_particle;
- }
+edm4hep::MCParticle HepMCToEDMConverter::convert(HepMC::GenParticle* hepmcParticle) {
+  edm4hep::MCParticle edm_particle;
+  edm_particle.setPDG(hepmcParticle->pdg_id());
+  edm_particle.setGeneratorStatus(hepmcParticle->status());
+  // look up charge from pdg_id
+  HepPDT::ParticleID particleID(hepmcParticle->pdg_id());
+  edm_particle.setCharge(particleID.charge());
+  // convert momentum
+  auto p = hepmcParticle->momentum();
+  edm_particle.setMomentum( {float(p.px()), float(p.py()), float(p.pz())} );
+
+  // convert vertex info
+  auto* prodVtx = hepmcParticle->production_vertex();
+
+  if ( prodVtx!=nullptr ) {
+    auto& pos = prodVtx->position();
+    edm_particle.setVertex( {float(pos.x()), float(pos.y()), float(pos.z())} );
+  }
+
+  return edm_particle;
+}
 
 HepMCToEDMConverter::HepMCToEDMConverter(const std::string& name, ISvcLocator* svcLoc) : GaudiAlgorithm(name, svcLoc) {
   declareProperty("hepmc", m_hepmchandle, "HepMC event handle (input)");

--- a/k4Gen/src/components/HepMCToEDMConverter.h
+++ b/k4Gen/src/components/HepMCToEDMConverter.h
@@ -8,6 +8,7 @@
 
 namespace edm4hep {
 class MCParticleCollection;
+class MCParticle;
 }
 
 class HepMCToEDMConverter : public GaudiAlgorithm {
@@ -30,5 +31,7 @@ private:
   DataHandle<HepMC::GenEvent> m_hepmchandle{"hepmc", Gaudi::DataHandle::Reader, this};
   /// Handle for the genparticles to be written
   DataHandle<edm4hep::MCParticleCollection> m_genphandle{"GenParticles", Gaudi::DataHandle::Writer, this};
+
+  edm4hep::MCParticle convert(HepMC::GenParticle* hepmcParticle);
 };
 #endif


### PR DESCRIPTION
Currently, `HepMCToEDMConverter` saves the momentum of particles only, though vertex information is integrated into `edm4hep::MCParticle`. This PR will put production vertex information from `HepMC::GenVertex` to `edm4hep::MCParticle` if it exists (note that in some cases it may not exist, e.g. beam particles).