### PR TITLE
Update HepMCToEDMConverter.cpp (mass conversion)

### DIFF
--- a/k4Gen/src/components/HepMCToEDMConverter.cpp
+++ b/k4Gen/src/components/HepMCToEDMConverter.cpp
@@ -17,6 +17,7 @@ edm4hep::MutableMCParticle HepMCToEDMConverter::convert(std::shared_ptr<const He
   // convert momentum
   auto p = hepmcParticle->momentum();
   edm_particle.setMomentum( {float(p.px()), float(p.py()), float(p.pz())} );
+  edm_particle.setMass( float ( hepmcParticle->generated_mass() ) );
 
   // add spin (particle helicity) information if available
   std::shared_ptr<HepMC3::VectorFloatAttribute> spin = hepmcParticle->attribute<HepMC3::VectorFloatAttribute>("spin");

--- a/k4Gen/src/components/HepMCToEDMConverter.cpp
+++ b/k4Gen/src/components/HepMCToEDMConverter.cpp
@@ -17,7 +17,7 @@ edm4hep::MutableMCParticle HepMCToEDMConverter::convert(std::shared_ptr<const He
   // convert momentum
   auto p = hepmcParticle->momentum();
   edm_particle.setMomentum( {float(p.px()), float(p.py()), float(p.pz())} );
-  edm_particle.setMass( float ( hepmcParticle->generated_mass() ) );
+  edm_particle.setMass( double ( hepmcParticle->generated_mass() ) );
 
   // add spin (particle helicity) information if available
   std::shared_ptr<HepMC3::VectorFloatAttribute> spin = hepmcParticle->attribute<HepMC3::VectorFloatAttribute>("spin");


### PR DESCRIPTION
Added line to get mass. 

Mass was not converted which would result in mass being 0 for all particles after conversion.