### PR TITLE
Tidying up of GenAlg

### DIFF
--- a/k4Gen/src/components/GenAlg.cpp
+++ b/k4Gen/src/components/GenAlg.cpp
@@ -8,18 +8,13 @@
 // HepMC3
 #include "HepMC3/GenEvent.h"
 
-
 DECLARE_COMPONENT(GenAlg)
 
-
 GenAlg::GenAlg(const std::string& name, ISvcLocator* svcLoc) : Gaudi::Algorithm(name, svcLoc) {
-  declareProperty("SignalProvider", m_signalProvider,
-                  "Signal events provider tool");
+  declareProperty("SignalProvider", m_signalProvider, "Signal events provider tool");
   declareProperty("PileUpTool", m_pileUpTool, "Pileup tool");
-  declareProperty("PileUpProvider", m_pileUpProvider,
-                  "Pileup events provider tool");
-  declareProperty("VertexSmearingTool", m_vertexSmearingTool,
-                  "Vertex smearing tool");
+  declareProperty("PileUpProvider", m_pileUpProvider, "Pileup events provider tool");
+  declareProperty("VertexSmearingTool", m_vertexSmearingTool, "Vertex smearing tool");
   declareProperty("HepMCMergeTool", m_hepmcMergeTool, "Event merge tool");
   declareProperty("hepmc", m_hepmcHandle, "HepMC event handle (output)");
 }
@@ -27,7 +22,8 @@ GenAlg::GenAlg(const std::string& name, ISvcLocator* svcLoc) : Gaudi::Algorithm(
 StatusCode GenAlg::initialize() {
   {
     StatusCode sc = Gaudi::Algorithm::initialize();
-    if (!sc.isSuccess()) return sc;
+    if (!sc.isSuccess())
+      return sc;
   }
 
   if (!m_signalProvider) {
@@ -66,13 +62,15 @@ StatusCode GenAlg::execute(const EventContext&) const {
   // Get the event from the signal provider
   {
     StatusCode sc = m_signalProvider->getNextEvent(*theEvent);
-    if (!sc.isSuccess()) return sc;
+    if (!sc.isSuccess())
+      return sc;
   }
 
   // Smear vertex
   {
     StatusCode sc = m_vertexSmearingTool->smearVertex(*theEvent);
-    if (!sc.isSuccess()) return sc;
+    if (!sc.isSuccess())
+      return sc;
   }
 
   // Get number of pileup events
@@ -88,7 +86,8 @@ StatusCode GenAlg::execute(const EventContext&) const {
       for (unsigned int i_pileUp = 0; i_pileUp < numPileUp; ++i_pileUp) {
         auto puEvt = HepMC3::GenEvent();
         StatusCode sc = m_pileUpProvider->getNextEvent(puEvt);
-        if (!sc.isSuccess()) return sc;
+        if (!sc.isSuccess())
+          return sc;
 
         m_vertexSmearingTool->smearVertex(puEvt).ignore();
         eventVector.push_back(std::move(puEvt));
@@ -96,14 +95,13 @@ StatusCode GenAlg::execute(const EventContext&) const {
     }
 
     StatusCode sc = m_hepmcMergeTool->merge(*theEvent, eventVector);
-    if (!sc.isSuccess()) return sc;
+    if (!sc.isSuccess())
+      return sc;
   }
 
   debug() << "Event number: " << theEvent->event_number() << endmsg;
-  debug() << "Number of particles in the event: " << theEvent->particles().size()
-          << endmsg;
-  debug() << "Number of vertices in the event: " << theEvent->vertices().size()
-          << endmsg;
+  debug() << "Number of particles in the event: " << theEvent->particles().size() << endmsg;
+  debug() << "Number of vertices in the event: " << theEvent->vertices().size() << endmsg;
 
   return StatusCode::SUCCESS;
 }

--- a/k4Gen/src/components/GenAlg.cpp
+++ b/k4Gen/src/components/GenAlg.cpp
@@ -1,4 +1,3 @@
-// GenAlg
 #include "GenAlg.h"
 
 // Gaudi
@@ -9,7 +8,9 @@
 // HepMC3
 #include "HepMC3/GenEvent.h"
 
+
 DECLARE_COMPONENT(GenAlg)
+
 
 GenAlg::GenAlg(const std::string& name, ISvcLocator* svcLoc) : Gaudi::Algorithm(name, svcLoc) {
   declareProperty("SignalProvider", m_signalProvider,

--- a/k4Gen/src/components/GenAlg.cpp
+++ b/k4Gen/src/components/GenAlg.cpp
@@ -1,61 +1,110 @@
-
+// GenAlg
 #include "GenAlg.h"
 
+// Gaudi
 #include "GaudiKernel/IEventProcessor.h"
 #include "GaudiKernel/IIncidentSvc.h"
 #include "GaudiKernel/Incident.h"
 
+// HepMC3
 #include "HepMC3/GenEvent.h"
 
 DECLARE_COMPONENT(GenAlg)
 
 GenAlg::GenAlg(const std::string& name, ISvcLocator* svcLoc) : Gaudi::Algorithm(name, svcLoc) {
-
-  declareProperty("PileUpTool", m_pileUpTool);
-
-  declareProperty("VertexSmearingTool", m_vertexSmearingTool);
-
-  declareProperty("HepMCMergeTool", m_HepMCMergeTool);
-
-  declareProperty("SignalProvider", m_signalProvider);
-  declareProperty("PileUpProvider", m_pileUpProvider);
-
-  declareProperty("hepmc", m_hepmchandle, "HepMC event handle (output)");
+  declareProperty("SignalProvider", m_signalProvider,
+                  "Signal events provider tool");
+  declareProperty("PileUpTool", m_pileUpTool, "Pileup tool");
+  declareProperty("PileUpProvider", m_pileUpProvider,
+                  "Pileup events provider tool");
+  declareProperty("VertexSmearingTool", m_vertexSmearingTool,
+                  "Vertex smearing tool");
+  declareProperty("HepMCMergeTool", m_hepmcMergeTool, "Event merge tool");
+  declareProperty("hepmc", m_hepmcHandle, "HepMC event handle (output)");
 }
 
 StatusCode GenAlg::initialize() {
-  StatusCode sc = Gaudi::Algorithm::initialize();
-  if (!sc.isSuccess())
-    return sc;
-  return sc;
+  {
+    StatusCode sc = Gaudi::Algorithm::initialize();
+    if (!sc.isSuccess()) return sc;
+  }
+
+  if (!m_signalProvider) {
+    error() << "Signal event provider is missing!" << endmsg;
+    return StatusCode::FAILURE;
+  }
+
+  if (!m_vertexSmearingTool) {
+    error() << "Vertex smearing tool is missing!" << endmsg;
+    return StatusCode::FAILURE;
+  }
+
+  if (!m_pileUpTool) {
+    error() << "Pileup tool is missing!" << endmsg;
+    return StatusCode::FAILURE;
+  }
+
+  if (!m_pileUpProvider) {
+    error() << "Pileup provider is missing!" << endmsg;
+    return StatusCode::FAILURE;
+  }
+
+  if (!m_hepmcMergeTool) {
+    error() << "Event merge tool is missing!" << endmsg;
+    return StatusCode::FAILURE;
+  }
+
+  return StatusCode::SUCCESS;
 }
 
 StatusCode GenAlg::execute(const EventContext&) const {
-  HepMC3::GenEvent* theEvent = m_hepmchandle.createAndPut();
+  // Create empty event
+  HepMC3::GenEvent* theEvent = m_hepmcHandle.createAndPut();
   theEvent->set_units(HepMC3::Units::GEV, HepMC3::Units::MM);
+
+  // Get the event from the signal provider
+  {
+    StatusCode sc = m_signalProvider->getNextEvent(*theEvent);
+    if (!sc.isSuccess()) return sc;
+  }
+
+  // Smear vertex
+  {
+    StatusCode sc = m_vertexSmearingTool->smearVertex(*theEvent);
+    if (!sc.isSuccess()) return sc;
+  }
+
+  // Get number of pileup events
   const unsigned int numPileUp = m_pileUpTool->numberOfPileUp();
-  std::vector<HepMC3::GenEvent> eventVector;
-  eventVector.reserve(numPileUp + 1);
-  StatusCode sc;
-  if (!m_signalProvider.empty()) {
-    sc = m_signalProvider->getNextEvent(*theEvent);
-  }
-  if (StatusCode::SUCCESS != sc) {
-    return sc;
-  }
-  m_vertexSmearingTool->smearVertex(*theEvent).ignore();
-  if (!m_pileUpProvider.empty()) {
-    for (unsigned int i_pileUp = 0; i_pileUp < numPileUp; ++i_pileUp) {
-      auto puEvt = HepMC3::GenEvent();
-      sc = m_pileUpProvider->getNextEvent(puEvt);
-      if (StatusCode::SUCCESS != sc) {
-        return sc;
+  debug() << "Number of pileup events: " << numPileUp << endmsg;
+
+  // Merge in pileup
+  if (numPileUp > 0) {
+    std::vector<HepMC3::GenEvent> eventVector;
+    eventVector.reserve(numPileUp + 1);
+
+    if (!m_pileUpProvider.empty()) {
+      for (unsigned int i_pileUp = 0; i_pileUp < numPileUp; ++i_pileUp) {
+        auto puEvt = HepMC3::GenEvent();
+        StatusCode sc = m_pileUpProvider->getNextEvent(puEvt);
+        if (!sc.isSuccess()) return sc;
+
+        m_vertexSmearingTool->smearVertex(puEvt).ignore();
+        eventVector.push_back(std::move(puEvt));
       }
-      m_vertexSmearingTool->smearVertex(puEvt).ignore();
-      eventVector.push_back(std::move(puEvt));
     }
+
+    StatusCode sc = m_hepmcMergeTool->merge(*theEvent, eventVector);
+    if (!sc.isSuccess()) return sc;
   }
-  return m_HepMCMergeTool->merge(*theEvent, eventVector);
+
+  debug() << "Event number: " << theEvent->event_number() << endmsg;
+  debug() << "Number of particles in the event: " << theEvent->particles().size()
+          << endmsg;
+  debug() << "Number of vertices in the event: " << theEvent->vertices().size()
+          << endmsg;
+
+  return StatusCode::SUCCESS;
 }
 
 StatusCode GenAlg::finalize() { return Gaudi::Algorithm::finalize(); }

--- a/k4Gen/src/components/GenAlg.h
+++ b/k4Gen/src/components/GenAlg.h
@@ -15,7 +15,7 @@
 #include "Generation/IVertexSmearingTool.h"
 
 namespace HepMC3 {
-  class GenEvent;
+class GenEvent;
 }
 
 class GenAlg : public Gaudi::Algorithm {

--- a/k4Gen/src/components/GenAlg.h
+++ b/k4Gen/src/components/GenAlg.h
@@ -1,18 +1,21 @@
-
 #ifndef GENERATION_GENALG_H
 #define GENERATION_GENALG_H
 
+// Gaudi
+#include "Gaudi/Algorithm.h"
+#include "GaudiKernel/ToolHandle.h"
+
+// k4FWCore
+#include "k4FWCore/DataHandle.h"
+
+// k4Gen
 #include "Generation/IHepMCMergeTool.h"
 #include "Generation/IHepMCProviderTool.h"
 #include "Generation/IPileUpTool.h"
 #include "Generation/IVertexSmearingTool.h"
 
-#include "Gaudi/Algorithm.h"
-#include "GaudiKernel/ToolHandle.h"
-
-#include "k4FWCore/DataHandle.h"
 namespace HepMC3 {
-class GenEvent;
+  class GenEvent;
 }
 
 class GenAlg : public Gaudi::Algorithm {
@@ -28,17 +31,18 @@ public:
   virtual StatusCode finalize();
 
 private:
-  /// Tools to handle input from HepMC-file
+  /// Tool to provide signal event
   mutable ToolHandle<IHepMCProviderTool> m_signalProvider{"MomentumRangeParticleGun/HepMCProviderTool", this};
-  mutable ToolHandle<IHepMCProviderTool> m_pileUpProvider{"MomentumRangeParticleGun/HepMCProviderTool", this};
+  /// Tool to determine number of pileup events
   mutable ToolHandle<IPileUpTool> m_pileUpTool{"ConstPileUp/PileUpTool", this};
-
-  /// Tool to merge HepMC events
-  mutable ToolHandle<IHepMCMergeTool> m_HepMCMergeTool{"HepMCSimpleMerge/HepMCMergeTool", this};
-  // Tool to smear vertices
+  /// Tool to provide pile up event(s)
+  mutable ToolHandle<IHepMCProviderTool> m_pileUpProvider{"MomentumRangeParticleGun/HepMCProviderTool", this};
+  // Tool to smear vertex
   mutable ToolHandle<IVertexSmearingTool> m_vertexSmearingTool{"FlatSmearVertex/VertexSmearingTool", this};
-  // output handle for finished event
-  mutable DataHandle<HepMC3::GenEvent> m_hepmchandle{"hepmc", Gaudi::DataHandle::Writer, this};
+  /// Tool to merge HepMC events
+  mutable ToolHandle<IHepMCMergeTool> m_hepmcMergeTool{"HepMCSimpleMerge/HepMCMergeTool", this};
+  // Output handle for finished event
+  mutable DataHandle<HepMC3::GenEvent> m_hepmcHandle{"hepmc", Gaudi::DataHandle::Writer, this};
 };
 
 #endif // GENERATION_GENALG_H

--- a/k4Gen/src/components/HepMCToEDMConverter.cpp
+++ b/k4Gen/src/components/HepMCToEDMConverter.cpp
@@ -6,9 +6,7 @@
 // EDM4hep
 #include "edm4hep/MCParticleCollection.h"
 
-
 DECLARE_COMPONENT(HepMCToEDMConverter)
-
 
 edm4hep::MutableMCParticle
 HepMCToEDMConverter::convert(std::shared_ptr<const HepMC3::GenParticle> hepmcParticle) const {
@@ -60,9 +58,9 @@ StatusCode HepMCToEDMConverter::execute(const EventContext&) const {
   edm4hep::MCParticleCollection* particles = new edm4hep::MCParticleCollection();
 
   std::unordered_map<unsigned int, edm4hep::MutableMCParticle> _map;
-  for (auto _p: evt->particles()) {
-    debug() << "Converting HepMC particle with PDG ID \"" << _p->pdg_id()
-            << "\" and ID \"" << _p->id() << "\"" << endmsg;
+  for (auto _p : evt->particles()) {
+    debug() << "Converting HepMC particle with PDG ID \"" << _p->pdg_id() << "\" and ID \"" << _p->id() << "\""
+            << endmsg;
     if (_map.find(_p->id()) == _map.end()) {
       edm4hep::MutableMCParticle edm_particle = convert(_p);
       _map.insert({_p->id(), edm_particle});

--- a/k4Gen/src/components/HepMCToEDMConverter.cpp
+++ b/k4Gen/src/components/HepMCToEDMConverter.cpp
@@ -56,8 +56,9 @@ StatusCode HepMCToEDMConverter::execute(const EventContext&) const {
   edm4hep::MCParticleCollection* particles = new edm4hep::MCParticleCollection();
 
   std::unordered_map<unsigned int, edm4hep::MutableMCParticle> _map;
-  for (auto _p : evt->particles()) {
-    debug() << "Converting hepmc particle with Pdg_ID \t" << _p->pdg_id() << "and id \t" << _p->id() << endmsg;
+  for (auto _p: evt->particles()) {
+    debug() << "Converting HepMC particle with PDG ID \"" << _p->pdg_id()
+            << "\" and ID \"" << _p->id() << "\"" << endmsg;
     if (_map.find(_p->id()) == _map.end()) {
       edm4hep::MutableMCParticle edm_particle = convert(_p);
       _map.insert({_p->id(), edm_particle});

--- a/k4Gen/src/components/HepMCToEDMConverter.cpp
+++ b/k4Gen/src/components/HepMCToEDMConverter.cpp
@@ -59,8 +59,8 @@ StatusCode HepMCToEDMConverter::execute(const EventContext&) const {
 
   std::unordered_map<unsigned int, edm4hep::MutableMCParticle> _map;
   for (auto _p : evt->particles()) {
-    debug() << "Converting HepMC particle with PDG ID \"" << _p->pdg_id() << "\" and ID \"" << _p->id() << "\""
-            << endmsg;
+    verbose() << "Converting HepMC particle with PDG ID \"" << _p->pdg_id() << "\" and ID \"" << _p->id() << "\""
+              << endmsg;
     if (_map.find(_p->id()) == _map.end()) {
       edm4hep::MutableMCParticle edm_particle = convert(_p);
       _map.insert({_p->id(), edm_particle});

--- a/k4Gen/src/components/HepMCToEDMConverter.cpp
+++ b/k4Gen/src/components/HepMCToEDMConverter.cpp
@@ -1,10 +1,14 @@
 #include "HepMCToEDMConverter.h"
-#include "GaudiKernel/PhysicalConstants.h"
-#include "HepMC3/Attribute.h"
+// HepMC
+#include "HepMC3/GenVertex.h"
+// HepPDT
 #include "HepPDT/ParticleID.hh"
+// EDM4hep
 #include "edm4hep/MCParticleCollection.h"
 
+
 DECLARE_COMPONENT(HepMCToEDMConverter)
+
 
 edm4hep::MutableMCParticle
 HepMCToEDMConverter::convert(std::shared_ptr<const HepMC3::GenParticle> hepmcParticle) const {

--- a/k4Gen/src/components/HepMCToEDMConverter.h
+++ b/k4Gen/src/components/HepMCToEDMConverter.h
@@ -1,16 +1,16 @@
 #ifndef GENERATION_HEPMCTOEDMCONVERTER_H
 #define GENERATION_HEPMCTOEDMCONVERTER_H
 
+// Gaudi
 #include "Gaudi/Algorithm.h"
+// k4FWCore
+#include "k4FWCore/DataHandle.h"
+// HepMC
 #include "HepMC3/GenEvent.h"
 #include "HepMC3/GenParticle.h"
-#include "HepMC3/GenVertex.h"
-#include "HepMC3/Units.h"
-#include "k4FWCore/DataHandle.h"
 
 namespace edm4hep {
 class MCParticleCollection;
-class MCParticle;
 class MutableMCParticle;
 } // namespace edm4hep
 

--- a/k4Gen/src/components/PythiaInterface.h
+++ b/k4Gen/src/components/PythiaInterface.h
@@ -50,14 +50,12 @@ private:
   HepMC3::Pythia8ToHepMC3 m_pythiaToHepMC;
   /// Name of Pythia configuration file with Pythia simulation
   /// settings & input LHE file (if required)
-  Gaudi::Property<std::string> m_pythiacard{
-      this, "pythiacard", "Pythia_minbias_pp_100TeV.cmd",
-      "Name of the Pythia cmd file"};
+  Gaudi::Property<std::string> m_pythiacard{this, "pythiacard", "Pythia_minbias_pp_100TeV.cmd",
+                                            "Name of the Pythia cmd file"};
 
   /// Extra settings for Pythia
   Gaudi::Property<std::vector<std::string>> m_pythia_extrasettings{
-      this, "pythiaExtraSettings", {""},
-      "Additional strings with Pythia settings, applied after the card."};
+      this, "pythiaExtraSettings", {""}, "Additional strings with Pythia settings, applied after the card."};
 
   /// Pythia8 engine for jet clustering
   std::unique_ptr<Pythia8::SlowJet> m_slowJet{nullptr};

--- a/k4Gen/src/components/PythiaInterface.h
+++ b/k4Gen/src/components/PythiaInterface.h
@@ -48,23 +48,24 @@ private:
   std::unique_ptr<Pythia8::Pythia> m_pythiaSignal;
   /// Interface for conversion from Pythia8::Event to HepMC event.
   HepMC3::Pythia8ToHepMC3 m_pythiaToHepMC;
-  /// Name of Pythia configuration file with Pythia simulation settings & input LHE file (if required)
-  Gaudi::Property<std::string> m_pythiacard{this, "pythiacard",
-                                            "Pythia_minbias_pp_100TeV.cmd"
-                                            "Name of the Pythia cmd file"};
+  /// Name of Pythia configuration file with Pythia simulation
+  /// settings & input LHE file (if required)
+  Gaudi::Property<std::string> m_pythiacard{
+      this, "pythiacard", "Pythia_minbias_pp_100TeV.cmd",
+      "Name of the Pythia cmd file"};
 
+  /// Extra settings for Pythia
   Gaudi::Property<std::vector<std::string>> m_pythia_extrasettings{
-      this, "pythiaExtraSettings", {""}, "Additional strings with Pythia settings, applied after the card."};
+      this, "pythiaExtraSettings", {""},
+      "Additional strings with Pythia settings, applied after the card."};
+
   /// Pythia8 engine for jet clustering
   std::unique_ptr<Pythia8::SlowJet> m_slowJet{nullptr};
-  // Tool to smear vertices
-  ToolHandle<IVertexSmearingTool> m_vertexSmearingTool;
   // Output handle for ME/PS matching variables
   mutable DataHandle<std::vector<float>> m_handleMePsMatchingVars{"mePsMatchingVars", Gaudi::DataHandle::Writer, this};
 
-  int m_nAbort{0};
-  int m_iAbort{0};
-  int m_iEvent{0};
+  // Maximum number of aborts before giving up
+  int m_maxAborts{0};
 
   // -- aMCatNLO
   bool m_doMePsMatching{false};
@@ -94,12 +95,8 @@ private:
                                                         "Name of the EvtGen Particle Data File"};
 
   Gaudi::Property<std::vector<int>> m_evtGenExcludes{
-      this, "EvtGenExcludes", {}, "Pdg IDs of particles not to decay with EvtGen"};
-#if PYTHIA_VERSION_INTEGER < 8300
-  EvtGenDecays* m_evtgen = nullptr;
-#else
+      this, "EvtGenExcludes", {}, "PDG IDs of particles not to decay with EvtGen"};
   Pythia8::EvtGenDecays* m_evtgen = nullptr;
-#endif
 };
 
 #endif // GENERATION_PYTHIAINTERFACE_H


### PR DESCRIPTION
The PR is tidying up the GenAlg and surrounding tools/algorithms and also implements:
* Exiting when tools are not present
* Fix crash in DEBUG mode
* Move printouts for individual particles into VERBOSE
* Removes support for versions of Pythia older than 8.3
* Removes vertex smearing tool handle from `PythiaInterface` as it was never implemented and is also in `GenAlg`