### PR TITLE
Do not use GaudiAlg

### DIFF
--- a/k4Gen/CMakeLists.txt
+++ b/k4Gen/CMakeLists.txt
@@ -12,7 +12,6 @@ gaudi_add_module(k4Gen
                  SOURCES ${k4gen_plugin_sources}
                  LINK Gaudi::GaudiKernel 
                       ${HEPMC3_LIBRARIES}
-                      Gaudi::GaudiAlgLib
                       k4FWCore::k4FWCore
                       HepPDT::heppdt
                       EvtGen::EvtGen

--- a/k4Gen/src/components/ConstPileUp.cpp
+++ b/k4Gen/src/components/ConstPileUp.cpp
@@ -3,14 +3,14 @@
 DECLARE_COMPONENT(ConstPileUp)
 
 ConstPileUp::ConstPileUp(const std::string& type, const std::string& name, const IInterface* parent)
-    : GaudiTool(type, name, parent) {
+    : AlgTool(type, name, parent) {
   declareInterface<IPileUpTool>(this);
 }
 
 ConstPileUp::~ConstPileUp() { ; }
 
 StatusCode ConstPileUp::initialize() {
-  StatusCode sc = GaudiTool::initialize();
+  StatusCode sc = AlgTool::initialize();
   printPileUpCounters();
   return sc;
 }

--- a/k4Gen/src/components/ConstPileUp.h
+++ b/k4Gen/src/components/ConstPileUp.h
@@ -2,7 +2,7 @@
 #define GENERATION_CONSTPILEUP_H
 
 #include "Generation/IPileUpTool.h"
-#include "GaudiAlg/GaudiTool.h"
+#include "GaudiKernel/AlgTool.h"
 
 /** @class ConstPileUp 
  *
@@ -14,7 +14,7 @@
  *  @author Valentin Volkl
  *  @date   2015-12-16
  */
-class ConstPileUp : public GaudiTool, virtual public IPileUpTool {
+class ConstPileUp : public AlgTool, virtual public IPileUpTool {
 public:
   ConstPileUp(const std::string& type, const std::string& name, const IInterface* parent);
   virtual ~ConstPileUp();

--- a/k4Gen/src/components/ConstPtParticleGun.cpp
+++ b/k4Gen/src/components/ConstPtParticleGun.cpp
@@ -22,7 +22,7 @@ StatusCode ConstPtParticleGun::initialize() {
   StatusCode sc = AlgTool::initialize();
   if (!sc.isSuccess()) return sc;
   // initialize random number generator
-  IRndmGenSvc* randSvc = svc<IRndmGenSvc>("RndmGenSvc", true);
+  IRndmGenSvc* randSvc = service<IRndmGenSvc>("RndmGenSvc", true);
   sc = m_flatGenerator.initialize(randSvc, Rndm::Flat(0., 1.));
   if (!sc.isSuccess()) {
     error() << "Cannot initialize flat generator";

--- a/k4Gen/src/components/ConstPtParticleGun.cpp
+++ b/k4Gen/src/components/ConstPtParticleGun.cpp
@@ -12,14 +12,14 @@
 DECLARE_COMPONENT(ConstPtParticleGun)
 
 ConstPtParticleGun::ConstPtParticleGun(const std::string& type, const std::string& name, const IInterface* parent)
-    : GaudiTool(type, name, parent) {
+    : AlgTool(type, name, parent) {
   declareInterface<IParticleGunTool>(this);
 }
 
 ConstPtParticleGun::~ConstPtParticleGun() {}
 
 StatusCode ConstPtParticleGun::initialize() {
-  StatusCode sc = GaudiTool::initialize();
+  StatusCode sc = AlgTool::initialize();
   if (!sc.isSuccess()) return sc;
   // initialize random number generator
   IRndmGenSvc* randSvc = svc<IRndmGenSvc>("RndmGenSvc", true);

--- a/k4Gen/src/components/ConstPtParticleGun.cpp
+++ b/k4Gen/src/components/ConstPtParticleGun.cpp
@@ -24,9 +24,15 @@ StatusCode ConstPtParticleGun::initialize() {
   // initialize random number generator
   IRndmGenSvc* randSvc = svc<IRndmGenSvc>("RndmGenSvc", true);
   sc = m_flatGenerator.initialize(randSvc, Rndm::Flat(0., 1.));
-  if (!sc.isSuccess()) return Error("Cannot initialize flat generator");
+  if (!sc.isSuccess()) {
+    error() << "Cannot initialize flat generator";
+    return StatusCode::FAILURE;
+  }
   // check momentum and angles
-  if ((m_minEta > m_maxEta) || (m_minPhi > m_maxPhi)) return Error("Incorrect values for eta or phi!");
+  if ((m_minEta > m_maxEta) || (m_minPhi > m_maxPhi)) {
+    error() << "Incorrect values for eta or phi!";
+    return StatusCode::FAILURE;
+  }
   m_deltaPhi = m_maxPhi - m_minPhi;
   m_deltaEta = m_maxEta - m_minEta;
   // setup particle information

--- a/k4Gen/src/components/ConstPtParticleGun.h
+++ b/k4Gen/src/components/ConstPtParticleGun.h
@@ -2,7 +2,7 @@
 #define GENERATION_CONSTPTPARTICLEGUN_H
 
 #include "k4FWCore/DataHandle.h"
-#include "GaudiAlg/GaudiTool.h"
+#include "GaudiKernel/AlgTool.h"
 #include "GaudiKernel/PhysicalConstants.h"
 #include "GaudiKernel/RndmGenerators.h"
 #include "GaudiKernel/SystemOfUnits.h"
@@ -14,7 +14,7 @@
  *  To be more flexible, the gun uses only pt and eta values from a list, if given,
  *  and only if the lists are empty draws the values from a distribution between min and max.
  */
-class ConstPtParticleGun : public GaudiTool, virtual public IParticleGunTool {
+class ConstPtParticleGun : public AlgTool, virtual public IParticleGunTool {
 public:
   ConstPtParticleGun(const std::string& type, const std::string& name, const IInterface* parent);
   virtual ~ConstPtParticleGun();

--- a/k4Gen/src/components/EDMToHepMCConverter.cpp
+++ b/k4Gen/src/components/EDMToHepMCConverter.cpp
@@ -12,14 +12,14 @@ using HepMC3::GenParticle;
 
 DECLARE_COMPONENT(EDMToHepMCConverter)
 
-EDMToHepMCConverter::EDMToHepMCConverter(const std::string& name, ISvcLocator* svcLoc) : GaudiAlgorithm(name, svcLoc) {
+EDMToHepMCConverter::EDMToHepMCConverter(const std::string& name, ISvcLocator* svcLoc) : Gaudi::Algorithm(name, svcLoc) {
   declareProperty("hepmc", m_hepmchandle, "HepMC event handle (output)");
   declareProperty("GenParticles", m_genphandle, "Generated particles collection (input)");
 }
 
-StatusCode EDMToHepMCConverter::initialize() { return GaudiAlgorithm::initialize(); }
+StatusCode EDMToHepMCConverter::initialize() { return Gaudi::Algorithm::initialize(); }
 
-StatusCode EDMToHepMCConverter::execute() {
+StatusCode EDMToHepMCConverter::execute(const EventContext&) const {
 
   auto particles = m_genphandle.get();
   // ownership of event given to data service at the end of execute
@@ -51,4 +51,4 @@ StatusCode EDMToHepMCConverter::execute() {
   return StatusCode::SUCCESS;
 }
 
-StatusCode EDMToHepMCConverter::finalize() { return GaudiAlgorithm::finalize(); }
+StatusCode EDMToHepMCConverter::finalize() { return Gaudi::Algorithm::finalize(); }

--- a/k4Gen/src/components/EDMToHepMCConverter.h
+++ b/k4Gen/src/components/EDMToHepMCConverter.h
@@ -2,7 +2,7 @@
 #define GENERATION_EDMTOHEPMCCONVERTER_H
 
 #include "k4FWCore/DataHandle.h"
-#include "GaudiAlg/GaudiAlgorithm.h"
+#include "Gaudi/Algorithm.h"
 #include "HepMC3/GenEvent.h"
 #include "HepMC3/Units.h"
 
@@ -10,7 +10,7 @@ namespace edm4hep {
 class MCParticleCollection;
 }
 
-class EDMToHepMCConverter : public GaudiAlgorithm {
+class EDMToHepMCConverter : public Gaudi::Algorithm {
 
 public:
   /// Constructor.
@@ -18,15 +18,15 @@ public:
   /// Initialize.
   virtual StatusCode initialize();
   /// Execute.
-  virtual StatusCode execute();
+  virtual StatusCode execute(const EventContext&) const;
   /// Finalize.
   virtual StatusCode finalize();
 
 private:
   /// Handle for the HepMC to be read
-  DataHandle<HepMC3::GenEvent> m_hepmchandle{"hepmc", Gaudi::DataHandle::Writer, this};
+  mutable DataHandle<HepMC3::GenEvent> m_hepmchandle{"hepmc", Gaudi::DataHandle::Writer, this};
   /// Handle for the genparticles to be written
-  DataHandle<edm4hep::MCParticleCollection> m_genphandle{"GenParticles", Gaudi::DataHandle::Reader, this};
+  mutable DataHandle<edm4hep::MCParticleCollection> m_genphandle{"GenParticles", Gaudi::DataHandle::Reader, this};
 };
 
 #endif

--- a/k4Gen/src/components/FlatSmearVertex.cpp
+++ b/k4Gen/src/components/FlatSmearVertex.cpp
@@ -68,7 +68,6 @@ StatusCode FlatSmearVertex::initialize() {
     return StatusCode::FAILURE;
   }
 
-  release(randSvc).ignore();
   return sc;
 }
 

--- a/k4Gen/src/components/FlatSmearVertex.cpp
+++ b/k4Gen/src/components/FlatSmearVertex.cpp
@@ -14,7 +14,7 @@ DECLARE_COMPONENT(FlatSmearVertex)
 
 /// Standard constructor, initializes variables
 FlatSmearVertex::FlatSmearVertex(const std::string& type, const std::string& name, const IInterface* parent)
-    : GaudiTool(type, name, parent) {
+    : AlgTool(type, name, parent) {
   declareInterface<IVertexSmearingTool>(this);
 }
 
@@ -25,7 +25,7 @@ FlatSmearVertex::~FlatSmearVertex() { ; }
 // Initialize
 //=============================================================================
 StatusCode FlatSmearVertex::initialize() {
-  StatusCode sc = GaudiTool::initialize();
+  StatusCode sc = AlgTool::initialize();
   if (sc.isFailure()) return sc;
 
   IRndmGenSvc* randSvc = svc<IRndmGenSvc>("RndmGenSvc", true);

--- a/k4Gen/src/components/FlatSmearVertex.cpp
+++ b/k4Gen/src/components/FlatSmearVertex.cpp
@@ -28,7 +28,7 @@ StatusCode FlatSmearVertex::initialize() {
   StatusCode sc = AlgTool::initialize();
   if (sc.isFailure()) return sc;
 
-  IRndmGenSvc* randSvc = svc<IRndmGenSvc>("RndmGenSvc", true);
+  IRndmGenSvc* randSvc = service<IRndmGenSvc>("RndmGenSvc", true);
   if (m_xmin > m_xmax) {
     error() << "xMin > xMax !";
     return StatusCode::FAILURE;

--- a/k4Gen/src/components/FlatSmearVertex.cpp
+++ b/k4Gen/src/components/FlatSmearVertex.cpp
@@ -29,9 +29,18 @@ StatusCode FlatSmearVertex::initialize() {
   if (sc.isFailure()) return sc;
 
   IRndmGenSvc* randSvc = svc<IRndmGenSvc>("RndmGenSvc", true);
-  if (m_xmin > m_xmax) return Error("xMin > xMax !");
-  if (m_ymin > m_ymax) return Error("yMin > yMax !");
-  if (m_zmin > m_zmax) return Error("zMin > zMax !");
+  if (m_xmin > m_xmax) {
+    error() << "xMin > xMax !";
+    return StatusCode::FAILURE;
+  }
+  if (m_ymin > m_ymax) {
+    error() << "yMin > yMax !";
+    return StatusCode::FAILURE;
+  }
+  if (m_zmin > m_zmax) {
+    error() << "zMin > zMax !";
+    return StatusCode::FAILURE;
+  }
 
   sc = m_flatDist.initialize(randSvc, Rndm::Flat(0., 1.));
 
@@ -43,7 +52,8 @@ StatusCode FlatSmearVertex::initialize() {
   } else if (m_zDir == 0) {
     infoMsg = " with TOF of interaction equal to zero ";
   } else {
-    return Error("BeamDirection can only be set to -1 or 1, or 0 to switch off TOF");
+    error() << "BeamDirection can only be set to -1 or 1, or 0 to switch off TOF";
+    return StatusCode::FAILURE;
   }
 
   info() << "Smearing of interaction point with flat distribution "
@@ -53,7 +63,10 @@ StatusCode FlatSmearVertex::initialize() {
          << m_ymin / Gaudi::Units::mm << " mm <= y <= " << m_ymax / Gaudi::Units::mm << " mm and "
          << m_zmin / Gaudi::Units::mm << " mm <= z <= " << m_zmax / Gaudi::Units::mm << " mm." << endmsg;
 
-  if (!sc.isSuccess()) return Error("Could not initialize flat random number generator");
+  if (!sc.isSuccess()) {
+    error() << "Could not initialize flat random number generator";
+    return StatusCode::FAILURE;
+  }
 
   release(randSvc).ignore();
   return sc;

--- a/k4Gen/src/components/FlatSmearVertex.h
+++ b/k4Gen/src/components/FlatSmearVertex.h
@@ -1,7 +1,7 @@
 #ifndef GENERATION_FLATSMEARVERTEX_H
 #define GENERATION_FLATSMEARVERTEX_H
 
-#include "GaudiAlg/GaudiTool.h"
+#include "GaudiKernel/AlgTool.h"
 #include "GaudiKernel/RndmGenerators.h"
 #include "GaudiKernel/SystemOfUnits.h"
 
@@ -18,7 +18,7 @@
  *  @author Daniel Funke
  *  @date   2008-05-18
  */
-class FlatSmearVertex : public GaudiTool, virtual public IVertexSmearingTool {
+class FlatSmearVertex : public AlgTool, virtual public IVertexSmearingTool {
 public:
   /// Standard constructor
   FlatSmearVertex(const std::string& type, const std::string& name, const IInterface* parent);

--- a/k4Gen/src/components/GaussSmearVertex.cpp
+++ b/k4Gen/src/components/GaussSmearVertex.cpp
@@ -29,7 +29,7 @@ StatusCode GaussSmearVertex::initialize() {
   StatusCode sc = AlgTool::initialize();
   if (sc.isFailure()) return sc;
 
-  IRndmGenSvc* randSvc = svc<IRndmGenSvc>("RndmGenSvc", true);
+  IRndmGenSvc* randSvc = service<IRndmGenSvc>("RndmGenSvc", true);
 
 
 

--- a/k4Gen/src/components/GaussSmearVertex.cpp
+++ b/k4Gen/src/components/GaussSmearVertex.cpp
@@ -47,7 +47,6 @@ StatusCode GaussSmearVertex::initialize() {
     return StatusCode::FAILURE;
   }
 
-  release(randSvc).ignore();
   return sc;
 }
 

--- a/k4Gen/src/components/GaussSmearVertex.cpp
+++ b/k4Gen/src/components/GaussSmearVertex.cpp
@@ -42,7 +42,10 @@ StatusCode GaussSmearVertex::initialize() {
   info() << " with " << m_xsig / Gaudi::Units::mm << " mm  standard deviation in x " << m_ysig / Gaudi::Units::mm
          << " mm in y and " << m_zsig / Gaudi::Units::mm << " mm in z." << endmsg;
 
-  if (!sc.isSuccess()) return Error("Could not initialize normal random number generator");
+  if (!sc.isSuccess()) {
+    error() << "Could not initialize normal random number generator";
+    return StatusCode::FAILURE;
+  }
 
   release(randSvc).ignore();
   return sc;

--- a/k4Gen/src/components/GaussSmearVertex.cpp
+++ b/k4Gen/src/components/GaussSmearVertex.cpp
@@ -14,7 +14,7 @@ DECLARE_COMPONENT(GaussSmearVertex)
 
 /// Standard constructor, initializes variables
 GaussSmearVertex::GaussSmearVertex(const std::string& type, const std::string& name, const IInterface* parent)
-    : GaudiTool(type, name, parent) {
+    : AlgTool(type, name, parent) {
   declareInterface<IVertexSmearingTool>(this);
 
 }
@@ -26,7 +26,7 @@ GaussSmearVertex::~GaussSmearVertex() { ; }
 // Initialize
 //=============================================================================
 StatusCode GaussSmearVertex::initialize() {
-  StatusCode sc = GaudiTool::initialize();
+  StatusCode sc = AlgTool::initialize();
   if (sc.isFailure()) return sc;
 
   IRndmGenSvc* randSvc = svc<IRndmGenSvc>("RndmGenSvc", true);

--- a/k4Gen/src/components/GaussSmearVertex.h
+++ b/k4Gen/src/components/GaussSmearVertex.h
@@ -1,7 +1,7 @@
 #ifndef GENERATION_GAUSSSMEARVERTEX_H
 #define GENERATION_GAUSSSMEARVERTEX_H
 
-#include "GaudiAlg/GaudiTool.h"
+#include "GaudiKernel/AlgTool.h"
 #include "GaudiKernel/PhysicalConstants.h"
 #include "GaudiKernel/RndmGenerators.h"
 
@@ -13,7 +13,7 @@
  *  Concrete implementation of a IVertexSmearingTool.
  *
  */
-class GaussSmearVertex : public GaudiTool, virtual public IVertexSmearingTool {
+class GaussSmearVertex : public AlgTool, virtual public IVertexSmearingTool {
 public:
   /// Standard constructor
   GaussSmearVertex(const std::string& type, const std::string& name, const IInterface* parent);

--- a/k4Gen/src/components/GenAlg.cpp
+++ b/k4Gen/src/components/GenAlg.cpp
@@ -9,7 +9,7 @@
 
 DECLARE_COMPONENT(GenAlg)
 
-GenAlg::GenAlg(const std::string& name, ISvcLocator* svcLoc) : GaudiAlgorithm(name, svcLoc) {
+GenAlg::GenAlg(const std::string& name, ISvcLocator* svcLoc) : Gaudi::Algorithm(name, svcLoc) {
 
   declareProperty("PileUpTool", m_pileUpTool);
 
@@ -24,12 +24,12 @@ GenAlg::GenAlg(const std::string& name, ISvcLocator* svcLoc) : GaudiAlgorithm(na
 }
 
 StatusCode GenAlg::initialize() {
-  StatusCode sc = GaudiAlgorithm::initialize();
+  StatusCode sc = Gaudi::Algorithm::initialize();
   if (!sc.isSuccess()) return sc;
   return sc;
 }
 
-StatusCode GenAlg::execute() {
+StatusCode GenAlg::execute(const EventContext&) const {
   HepMC3::GenEvent* theEvent = m_hepmchandle.createAndPut();
   theEvent->set_units(HepMC3::Units::GEV, HepMC3::Units::MM);
   const unsigned int numPileUp = m_pileUpTool->numberOfPileUp();
@@ -57,4 +57,4 @@ StatusCode GenAlg::execute() {
   return m_HepMCMergeTool->merge(*theEvent, eventVector);
 }
 
-StatusCode GenAlg::finalize() { return GaudiAlgorithm::finalize(); }
+StatusCode GenAlg::finalize() { return Gaudi::Algorithm::finalize(); }

--- a/k4Gen/src/components/GenAlg.h
+++ b/k4Gen/src/components/GenAlg.h
@@ -31,14 +31,14 @@ public:
 
 private:
   /// Tools to handle input from HepMC-file
-  ToolHandle<IHepMCProviderTool> m_signalProvider{"MomentumRangeParticleGun/HepMCProviderTool", this};
-  ToolHandle<IHepMCProviderTool> m_pileUpProvider{"MomentumRangeParticleGun/HepMCProviderTool", this};
+  mutable ToolHandle<IHepMCProviderTool> m_signalProvider{"MomentumRangeParticleGun/HepMCProviderTool", this};
+  mutable ToolHandle<IHepMCProviderTool> m_pileUpProvider{"MomentumRangeParticleGun/HepMCProviderTool", this};
   ToolHandle<IPileUpTool> m_pileUpTool{"ConstPileUp/PileUpTool", this};
 
   /// Tool to merge HepMC events
-  ToolHandle<IHepMCMergeTool> m_HepMCMergeTool{"HepMCSimpleMerge/HepMCMergeTool", this};
+  mutable ToolHandle<IHepMCMergeTool> m_HepMCMergeTool{"HepMCSimpleMerge/HepMCMergeTool", this};
   // Tool to smear vertices
-  ToolHandle<IVertexSmearingTool> m_vertexSmearingTool{"FlatSmearVertex/VertexSmearingTool", this};
+  mutable ToolHandle<IVertexSmearingTool> m_vertexSmearingTool{"FlatSmearVertex/VertexSmearingTool", this};
   // output handle for finished event
   mutable DataHandle<HepMC3::GenEvent> m_hepmchandle{"hepmc", Gaudi::DataHandle::Writer, this};
 };

--- a/k4Gen/src/components/GenAlg.h
+++ b/k4Gen/src/components/GenAlg.h
@@ -33,7 +33,7 @@ private:
   /// Tools to handle input from HepMC-file
   mutable ToolHandle<IHepMCProviderTool> m_signalProvider{"MomentumRangeParticleGun/HepMCProviderTool", this};
   mutable ToolHandle<IHepMCProviderTool> m_pileUpProvider{"MomentumRangeParticleGun/HepMCProviderTool", this};
-  ToolHandle<IPileUpTool> m_pileUpTool{"ConstPileUp/PileUpTool", this};
+  mutable ToolHandle<IPileUpTool> m_pileUpTool{"ConstPileUp/PileUpTool", this};
 
   /// Tool to merge HepMC events
   mutable ToolHandle<IHepMCMergeTool> m_HepMCMergeTool{"HepMCSimpleMerge/HepMCMergeTool", this};

--- a/k4Gen/src/components/GenAlg.h
+++ b/k4Gen/src/components/GenAlg.h
@@ -8,7 +8,7 @@
 #include "Generation/IVertexSmearingTool.h"
 
 
-#include "GaudiAlg/GaudiAlgorithm.h"
+#include "Gaudi/Algorithm.h"
 #include "GaudiKernel/ToolHandle.h"
 
 
@@ -17,7 +17,7 @@ namespace HepMC3 {
 class GenEvent;
 }
 
-class GenAlg : public GaudiAlgorithm {
+class GenAlg : public Gaudi::Algorithm {
 
 public:
   /// Constructor.
@@ -25,7 +25,7 @@ public:
   /// Initialize.
   virtual StatusCode initialize();
   /// Execute.
-  virtual StatusCode execute();
+  virtual StatusCode execute(const EventContext&) const;
   /// Finalize.
   virtual StatusCode finalize();
 
@@ -40,7 +40,7 @@ private:
   // Tool to smear vertices
   ToolHandle<IVertexSmearingTool> m_vertexSmearingTool{"FlatSmearVertex/VertexSmearingTool", this};
   // output handle for finished event
-  DataHandle<HepMC3::GenEvent> m_hepmchandle{"hepmc", Gaudi::DataHandle::Writer, this};
+  mutable DataHandle<HepMC3::GenEvent> m_hepmchandle{"hepmc", Gaudi::DataHandle::Writer, this};
 };
 
 #endif  // GENERATION_GENALG_H

--- a/k4Gen/src/components/GenParticleFilter.cpp
+++ b/k4Gen/src/components/GenParticleFilter.cpp
@@ -4,14 +4,14 @@
 
 DECLARE_COMPONENT(GenParticleFilter)
 
-GenParticleFilter::GenParticleFilter(const std::string& name, ISvcLocator* svcLoc) : GaudiAlgorithm(name, svcLoc) {
+GenParticleFilter::GenParticleFilter(const std::string& name, ISvcLocator* svcLoc) : Gaudi::Algorithm(name, svcLoc) {
   declareProperty("GenParticles", m_iGenpHandle, "Generator Particles to filter (input)");
   declareProperty("GenParticlesFiltered", m_oGenpHandle, "Filtered Generator particles (output)");
 }
 
-StatusCode GenParticleFilter::initialize() { return GaudiAlgorithm::initialize(); }
+StatusCode GenParticleFilter::initialize() { return Gaudi::Algorithm::initialize(); }
 
-StatusCode GenParticleFilter::execute() {
+StatusCode GenParticleFilter::execute(const EventContext&) const {
   const auto inparticles = m_iGenpHandle.get();
   auto particles = m_oGenpHandle.createAndPut();
   bool accept = false;
@@ -32,4 +32,4 @@ StatusCode GenParticleFilter::execute() {
   return StatusCode::SUCCESS;
 }
 
-StatusCode GenParticleFilter::finalize() { return GaudiAlgorithm::finalize(); }
+StatusCode GenParticleFilter::finalize() { return Gaudi::Algorithm::finalize(); }

--- a/k4Gen/src/components/GenParticleFilter.h
+++ b/k4Gen/src/components/GenParticleFilter.h
@@ -2,7 +2,7 @@
 #define GENERATION_GENPARTICLEFILTER_H
 
 #include "k4FWCore/DataHandle.h"
-#include "GaudiAlg/GaudiAlgorithm.h"
+#include "Gaudi/Algorithm.h"
 
 // forward declarations:
 namespace edm4hep {
@@ -18,7 +18,7 @@ class MCParticleCollection;
  *  @author J. Lingemann
 */
 
-class GenParticleFilter : public GaudiAlgorithm {
+class GenParticleFilter : public Gaudi::Algorithm {
 
 public:
   /// Constructor.
@@ -26,7 +26,7 @@ public:
   /// Initialize.
   virtual StatusCode initialize();
   /// Execute: Applies the filter
-  virtual StatusCode execute();
+  virtual StatusCode execute(const EventContext&) const;
   /// Finalize.
   virtual StatusCode finalize();
 
@@ -34,9 +34,9 @@ private:
   /// Particle statuses to accept
   Gaudi::Property<std::vector<unsigned>> m_accept{this, "accept", {1}, "Particle statuses to accept"};
   /// Handle for the ParticleCollection to be read
-  DataHandle<edm4hep::MCParticleCollection> m_iGenpHandle{"GenParticles", Gaudi::DataHandle::Reader, this};
+  mutable DataHandle<edm4hep::MCParticleCollection> m_iGenpHandle{"GenParticles", Gaudi::DataHandle::Reader, this};
   /// Handle for the genparticles to be written
-  DataHandle<edm4hep::MCParticleCollection> m_oGenpHandle{"GenParticlesFiltered", Gaudi::DataHandle::Writer, this};
+  mutable DataHandle<edm4hep::MCParticleCollection> m_oGenpHandle{"GenParticlesFiltered", Gaudi::DataHandle::Writer, this};
 };
 
 #endif  // GENERATION_GENPARTICLEFILTER_H

--- a/k4Gen/src/components/HepEVTReader.cpp
+++ b/k4Gen/src/components/HepEVTReader.cpp
@@ -12,7 +12,7 @@
 DECLARE_COMPONENT(HepEVTReader)
 
 HepEVTReader::HepEVTReader(const std::string& name, ISvcLocator* svcLoc):
-  GaudiAlgorithm(name, svcLoc),
+  Gaudi::Algorithm(name, svcLoc),
   m_filename() {
 
   declareProperty("HepEVTFilename", m_filename="", "Name of the HepEVT file to read");
@@ -21,7 +21,7 @@ HepEVTReader::HepEVTReader(const std::string& name, ISvcLocator* svcLoc):
 
 StatusCode HepEVTReader::initialize()
 {
-  StatusCode sc = GaudiAlgorithm::initialize();
+  StatusCode sc = Gaudi::Algorithm::initialize();
 
   m_input.open(m_filename.c_str(), std::ifstream::in);
 
@@ -34,7 +34,7 @@ StatusCode HepEVTReader::initialize()
   return StatusCode::SUCCESS;
 }
 
-StatusCode HepEVTReader::execute()
+StatusCode HepEVTReader::execute(const EventContext&) const
 {
   // First check the input file status
   if(m_input.eof())
@@ -118,5 +118,5 @@ StatusCode HepEVTReader::execute()
 StatusCode HepEVTReader::finalize() 
 {
   m_input.close();
-  return GaudiAlgorithm::finalize();
+  return Gaudi::Algorithm::finalize();
 }

--- a/k4Gen/src/components/HepEVTReader.h
+++ b/k4Gen/src/components/HepEVTReader.h
@@ -10,7 +10,7 @@
 
 #include "k4FWCore/DataHandle.h"
 
-#include "GaudiAlg/GaudiAlgorithm.h"
+#include "Gaudi/Algorithm.h"
 #include "GaudiKernel/ToolHandle.h"
 
 #include "GaudiKernel/SystemOfUnits.h"
@@ -28,7 +28,7 @@ class MCParticleCollection;
  *
  */
 
-class HepEVTReader: public GaudiAlgorithm {
+class HepEVTReader: public Gaudi::Algorithm {
 
 public:
   /// Constructor.
@@ -36,7 +36,7 @@ public:
   /// Initialize.
   virtual StatusCode initialize();
   /// Execute.
-  virtual StatusCode execute();
+  virtual StatusCode execute(const EventContext&) const;
   /// Finalize.
   virtual StatusCode finalize();
 
@@ -48,7 +48,7 @@ private:
   int m_format;
 
   /// Handle for the genparticles to be written
-  DataHandle<edm4hep::MCParticleCollection> m_genphandle {"GenParticles", Gaudi::DataHandle::Writer, this};
+  mutable DataHandle<edm4hep::MCParticleCollection> m_genphandle {"GenParticles", Gaudi::DataHandle::Writer, this};
 
 };
 

--- a/k4Gen/src/components/HepEVTReader.h
+++ b/k4Gen/src/components/HepEVTReader.h
@@ -43,7 +43,7 @@ public:
 private:
 
   std::string m_filename;
-  std::ifstream m_input;
+  mutable std::ifstream m_input;
   int NHEP;
   int m_format;
 

--- a/k4Gen/src/components/HepEVTReader.h
+++ b/k4Gen/src/components/HepEVTReader.h
@@ -44,7 +44,7 @@ private:
 
   std::string m_filename;
   mutable std::ifstream m_input;
-  int NHEP;
+  mutable int NHEP;
   int m_format;
 
   /// Handle for the genparticles to be written

--- a/k4Gen/src/components/HepMC2FileReader.cpp
+++ b/k4Gen/src/components/HepMC2FileReader.cpp
@@ -28,7 +28,7 @@ StatusCode HepMC2FileReader::initialize() {
 StatusCode HepMC2FileReader::getNextEvent(HepMC3::GenEvent& event) {
   if (!m_file->read_event(event)) {
     error() << "Premature end of file: Please set the number of events according to hepMC file." << endmsg;
-    return Error("Reached end of file before finished processing");
+    return StatusCode::FAILURE;
   }
   return StatusCode::SUCCESS;
 }

--- a/k4Gen/src/components/HepMC2FileReader.cpp
+++ b/k4Gen/src/components/HepMC2FileReader.cpp
@@ -8,7 +8,7 @@
 DECLARE_COMPONENT(HepMC2FileReader)
 
 HepMC2FileReader::HepMC2FileReader(const std::string& type, const std::string& name, const IInterface* parent)
-    : GaudiTool(type, name, parent), m_file(nullptr) {
+    : AlgTool(type, name, parent), m_file(nullptr) {
   declareInterface<IHepMCProviderTool>(this);
 }
 
@@ -21,7 +21,7 @@ StatusCode HepMC2FileReader::initialize() {
   }
   // open file using HepMC routines
   m_file = std::make_unique<HepMC3::ReaderAsciiHepMC2>(m_filename.value());
-  StatusCode sc = GaudiTool::initialize();
+  StatusCode sc = AlgTool::initialize();
   return sc;
 }
 
@@ -35,5 +35,5 @@ StatusCode HepMC2FileReader::getNextEvent(HepMC3::GenEvent& event) {
 
 StatusCode HepMC2FileReader::finalize() {
   m_file.reset();
-  return GaudiTool::finalize();
+  return AlgTool::finalize();
 }

--- a/k4Gen/src/components/HepMC2FileReader.h
+++ b/k4Gen/src/components/HepMC2FileReader.h
@@ -2,13 +2,13 @@
 #ifndef GENERATION_HEPMC2FILEREADER_H
 #define GENERATION_HEPMC2FILEREADER_H
 
-#include "GaudiAlg/GaudiTool.h"
+#include "GaudiKernel/AlgTool.h"
 #include "Generation/IHepMCProviderTool.h"
 
 #include "HepMC3/GenEvent.h"
 #include "HepMC3/ReaderAsciiHepMC2.h"
 
-class HepMC2FileReader : public GaudiTool, virtual public IHepMCProviderTool {
+class HepMC2FileReader : public AlgTool, virtual public IHepMCProviderTool {
 public:
   HepMC2FileReader(const std::string& type, const std::string& name, const IInterface* parent);
   virtual ~HepMC2FileReader();  ///< Destructor

--- a/k4Gen/src/components/HepMC2FileWriter.cpp
+++ b/k4Gen/src/components/HepMC2FileWriter.cpp
@@ -4,17 +4,17 @@
 
 DECLARE_COMPONENT(HepMC2FileWriter)
 
-HepMC2FileWriter::HepMC2FileWriter(const std::string& name, ISvcLocator* svcLoc) : GaudiAlgorithm(name, svcLoc) {
+HepMC2FileWriter::HepMC2FileWriter(const std::string& name, ISvcLocator* svcLoc) : Gaudi::Algorithm(name, svcLoc) {
   declareProperty("hepmc", m_hepmchandle, "The HepMC event to write to text file (input)");
 }
 
 StatusCode HepMC2FileWriter::initialize() {
 
   m_file = std::make_unique<HepMC3::WriterAsciiHepMC2>(m_filename.value());
-  return GaudiAlgorithm::initialize();
+  return Gaudi::Algorithm::initialize();
 }
 
-StatusCode HepMC2FileWriter::execute() {
+StatusCode HepMC2FileWriter::execute(const EventContext&) const {
   const HepMC3::GenEvent* theEvent = m_hepmchandle.get();
   m_file->write_event(*theEvent);
   return StatusCode::SUCCESS;
@@ -22,5 +22,5 @@ StatusCode HepMC2FileWriter::execute() {
 
 StatusCode HepMC2FileWriter::finalize() {
   m_file.reset();
-  return GaudiAlgorithm::finalize();
+  return Gaudi::Algorithm::finalize();
 }

--- a/k4Gen/src/components/HepMC2FileWriter.h
+++ b/k4Gen/src/components/HepMC2FileWriter.h
@@ -1,7 +1,7 @@
 #ifndef GENERATION_HEPMC2FILEWRITER_H
 #define GENERATION_HEPMC2FILEWRITER_H
 
-#include "GaudiAlg/GaudiAlgorithm.h"
+#include "Gaudi/Algorithm.h"
 
 #include "k4FWCore/DataHandle.h"
 
@@ -20,7 +20,7 @@ class WriterAsciiHepMC2;
  * done in the fccsw event data format.
  */
 
-class HepMC2FileWriter : public GaudiAlgorithm {
+class HepMC2FileWriter : public Gaudi::Algorithm {
 
 public:
   /// Constructor.
@@ -28,13 +28,13 @@ public:
   /// Initialize.
   virtual StatusCode initialize();
   /// Execute.
-  virtual StatusCode execute();
+  virtual StatusCode execute(const EventContext&) const;
   /// Finalize.
   virtual StatusCode finalize();
 
 private:
   /// Handle for the HepMC to be read
-  DataHandle<HepMC3::GenEvent> m_hepmchandle{"HepMC", Gaudi::DataHandle::Reader, this};
+  mutable DataHandle<HepMC3::GenEvent> m_hepmchandle{"HepMC", Gaudi::DataHandle::Reader, this};
   Gaudi::Property<std::string> m_filename{this, "Filename", "Output_HepMC.dat", "Name of the HepMC file to write"};
   std::unique_ptr<HepMC3::WriterAsciiHepMC2> m_file;
 };

--- a/k4Gen/src/components/HepMCDumper.cpp
+++ b/k4Gen/src/components/HepMCDumper.cpp
@@ -4,16 +4,16 @@
 
 DECLARE_COMPONENT(HepMCDumper)
 
-HepMCDumper::HepMCDumper(const std::string& name, ISvcLocator* svcLoc) : GaudiAlgorithm(name, svcLoc) {
+HepMCDumper::HepMCDumper(const std::string& name, ISvcLocator* svcLoc) : Gaudi::Algorithm(name, svcLoc) {
   declareProperty("hepmc", m_hepmchandle, "The HepMC event to dump");
 }
 
-StatusCode HepMCDumper::initialize() { return GaudiAlgorithm::initialize(); }
+StatusCode HepMCDumper::initialize() { return Gaudi::Algorithm::initialize(); }
 
-StatusCode HepMCDumper::execute() {
+StatusCode HepMCDumper::execute(const EventContext&) const {
   const HepMC3::GenEvent* theEvent = m_hepmchandle.get();
   HepMC3::Print::content(*theEvent);
   return StatusCode::SUCCESS;
 }
 
-StatusCode HepMCDumper::finalize() { return GaudiAlgorithm::finalize(); }
+StatusCode HepMCDumper::finalize() { return Gaudi::Algorithm::finalize(); }

--- a/k4Gen/src/components/HepMCDumper.h
+++ b/k4Gen/src/components/HepMCDumper.h
@@ -1,13 +1,13 @@
 #ifndef GENERATION_HEPMCDUMPER_H
 #define GENERATION_HEPMCDUMPER_H
 
-#include "GaudiAlg/GaudiAlgorithm.h"
+#include "Gaudi/Algorithm.h"
 
 #include "k4FWCore/DataHandle.h"
 
 #include "HepMC3/GenEvent.h"
 
-class HepMCDumper : public GaudiAlgorithm {
+class HepMCDumper : public Gaudi::Algorithm {
 
 public:
   /// Constructor.
@@ -15,13 +15,13 @@ public:
   /// Initialize.
   virtual StatusCode initialize();
   /// Execute.
-  virtual StatusCode execute();
+  virtual StatusCode execute(const EventContext&) const;
   /// Finalize.
   virtual StatusCode finalize();
 
 private:
   /// Handle for the HepMC to be read
-  DataHandle<HepMC3::GenEvent> m_hepmchandle{"hepmc", Gaudi::DataHandle::Reader, this};
+  mutable DataHandle<HepMC3::GenEvent> m_hepmchandle{"hepmc", Gaudi::DataHandle::Reader, this};
 };
 
 #endif  // GENERATION_HEPMCDUMPER_H

--- a/k4Gen/src/components/HepMCFileReader.cpp
+++ b/k4Gen/src/components/HepMCFileReader.cpp
@@ -28,7 +28,7 @@ StatusCode HepMCFileReader::initialize() {
 StatusCode HepMCFileReader::getNextEvent(HepMC3::GenEvent& event) {
   if (!m_file->read_event(event)) {
     error() << "Premature end of file: Please set the number of events according to hepMC file." << endmsg;
-    return Error("Reached end of file before finished processing");
+    return StatusCode::FAILURE;
   }
   return StatusCode::SUCCESS;
 }

--- a/k4Gen/src/components/HepMCFileReader.cpp
+++ b/k4Gen/src/components/HepMCFileReader.cpp
@@ -8,7 +8,7 @@
 DECLARE_COMPONENT(HepMCFileReader)
 
 HepMCFileReader::HepMCFileReader(const std::string& type, const std::string& name, const IInterface* parent)
-    : GaudiTool(type, name, parent), m_file(nullptr) {
+    : AlgTool(type, name, parent), m_file(nullptr) {
   declareInterface<IHepMCProviderTool>(this);
 }
 
@@ -21,7 +21,7 @@ StatusCode HepMCFileReader::initialize() {
   }
   // open file using HepMC routines
   m_file = std::make_unique<HepMC3::ReaderAscii>(m_filename.value());
-  StatusCode sc = GaudiTool::initialize();
+  StatusCode sc = AlgTool::initialize();
   return sc;
 }
 
@@ -35,5 +35,5 @@ StatusCode HepMCFileReader::getNextEvent(HepMC3::GenEvent& event) {
 
 StatusCode HepMCFileReader::finalize() {
   m_file.reset();
-  return GaudiTool::finalize();
+  return AlgTool::finalize();
 }

--- a/k4Gen/src/components/HepMCFileReader.h
+++ b/k4Gen/src/components/HepMCFileReader.h
@@ -2,13 +2,13 @@
 #ifndef GENERATION_HEPMCFILEREADER_H
 #define GENERATION_HEPMCFILEREADER_H
 
-#include "GaudiAlg/GaudiTool.h"
+#include "GaudiKernel/AlgTool.h"
 #include "Generation/IHepMCProviderTool.h"
 
 #include "HepMC3/GenEvent.h"
 #include "HepMC3/ReaderAscii.h"
 
-class HepMCFileReader : public GaudiTool, virtual public IHepMCProviderTool {
+class HepMCFileReader : public AlgTool, virtual public IHepMCProviderTool {
 public:
   HepMCFileReader(const std::string& type, const std::string& name, const IInterface* parent);
   virtual ~HepMCFileReader();  ///< Destructor

--- a/k4Gen/src/components/HepMCFileWriter.cpp
+++ b/k4Gen/src/components/HepMCFileWriter.cpp
@@ -4,16 +4,16 @@
 
 DECLARE_COMPONENT(HepMCFileWriter)
 
-HepMCFileWriter::HepMCFileWriter(const std::string& name, ISvcLocator* svcLoc) : GaudiAlgorithm(name, svcLoc) {
+HepMCFileWriter::HepMCFileWriter(const std::string& name, ISvcLocator* svcLoc) : Gaudi::Algorithm(name, svcLoc) {
   declareProperty("hepmc", m_hepmchandle, "The HepMC event to write to text file (input)");
 }
 
 StatusCode HepMCFileWriter::initialize() {
   m_file = std::make_unique<HepMC3::WriterAscii>(m_filename.value());
-  return GaudiAlgorithm::initialize();
+  return Gaudi::Algorithm::initialize();
 }
 
-StatusCode HepMCFileWriter::execute() {
+StatusCode HepMCFileWriter::execute(const EventContext&) const {
   const HepMC3::GenEvent* theEvent = m_hepmchandle.get();
   m_file->write_event(*theEvent);
   return StatusCode::SUCCESS;
@@ -21,5 +21,5 @@ StatusCode HepMCFileWriter::execute() {
 
 StatusCode HepMCFileWriter::finalize() {
   m_file.reset();
-  return GaudiAlgorithm::finalize();
+  return Gaudi::Algorithm::finalize();
 }

--- a/k4Gen/src/components/HepMCFileWriter.h
+++ b/k4Gen/src/components/HepMCFileWriter.h
@@ -1,7 +1,7 @@
 #ifndef GENERATION_HEPMCFILEWRITER_H
 #define GENERATION_HEPMCFILEWRITER_H
 
-#include "GaudiAlg/GaudiAlgorithm.h"
+#include "Gaudi/Algorithm.h"
 
 #include "k4FWCore/DataHandle.h"
 
@@ -20,7 +20,7 @@ class WriterAscii;
  * done in the fccsw event data format.
  */
 
-class HepMCFileWriter : public GaudiAlgorithm {
+class HepMCFileWriter : public Gaudi::Algorithm {
 
 public:
   /// Constructor.
@@ -28,13 +28,13 @@ public:
   /// Initialize.
   virtual StatusCode initialize();
   /// Execute.
-  virtual StatusCode execute();
+  virtual StatusCode execute(const EventContext&) const;
   /// Finalize.
   virtual StatusCode finalize();
 
 private:
   /// Handle for the HepMC to be read
-  DataHandle<HepMC3::GenEvent> m_hepmchandle{"HepMC", Gaudi::DataHandle::Reader, this};
+  mutable DataHandle<HepMC3::GenEvent> m_hepmchandle{"HepMC", Gaudi::DataHandle::Reader, this};
   Gaudi::Property<std::string> m_filename{this, "Filename", "Output_HepMC.dat", "Name of the HepMC file to write"};
   std::unique_ptr<HepMC3::WriterAscii> m_file;
 };

--- a/k4Gen/src/components/HepMCFullMerge.cpp
+++ b/k4Gen/src/components/HepMCFullMerge.cpp
@@ -11,14 +11,14 @@
 DECLARE_COMPONENT(HepMCFullMerge)
 
 HepMCFullMerge::HepMCFullMerge(const std::string& type, const std::string& name, const IInterface* parent)
-    : GaudiTool(type, name, parent) {
+    : AlgTool(type, name, parent) {
   declareInterface<IHepMCMergeTool>(this);
 }
 
 HepMCFullMerge::~HepMCFullMerge() {}
 
 StatusCode HepMCFullMerge::initialize() {
-  StatusCode sc = GaudiTool::initialize();
+  StatusCode sc = AlgTool::initialize();
   if (!sc.isSuccess()) return sc;
   return sc;
 }
@@ -47,4 +47,4 @@ StatusCode HepMCFullMerge::merge(HepMC3::GenEvent& signalEvent, const std::vecto
   return StatusCode::SUCCESS;
 }
 
-StatusCode HepMCFullMerge::finalize() { return GaudiTool::finalize(); }
+StatusCode HepMCFullMerge::finalize() { return AlgTool::finalize(); }

--- a/k4Gen/src/components/HepMCFullMerge.h
+++ b/k4Gen/src/components/HepMCFullMerge.h
@@ -5,7 +5,7 @@
 #include "k4FWCore/DataHandle.h"
 #include "Generation/IHepMCMergeTool.h"
 
-#include "GaudiAlg/GaudiTool.h"
+#include "GaudiKernel/AlgTool.h"
 #include "GaudiKernel/RndmGenerators.h"
 
 
@@ -15,7 +15,7 @@
  * Implementation partly due to pilemc https://pilemc.hepforge.org/
  */
 
-class HepMCFullMerge final: public GaudiTool, virtual public IHepMCMergeTool {
+class HepMCFullMerge final: public AlgTool, virtual public IHepMCMergeTool {
 public:
   HepMCFullMerge(const std::string& type, const std::string& name, const IInterface* parent);
 

--- a/k4Gen/src/components/HepMCHistograms.cpp
+++ b/k4Gen/src/components/HepMCHistograms.cpp
@@ -6,12 +6,12 @@
 
 DECLARE_COMPONENT(HepMCHistograms)
 
-HepMCHistograms::HepMCHistograms(const std::string& name, ISvcLocator* svcLoc) : GaudiAlgorithm(name, svcLoc) {
+HepMCHistograms::HepMCHistograms(const std::string& name, ISvcLocator* svcLoc) : Gaudi::Algorithm(name, svcLoc) {
   declareProperty("hepmc", m_hepmchandle);
 }
 
 StatusCode HepMCHistograms::initialize() {
-  if (GaudiAlgorithm::initialize().isFailure()) return StatusCode::FAILURE;
+  if (Gaudi::Algorithm::initialize().isFailure()) return StatusCode::FAILURE;
 
   if (service("THistSvc", m_ths).isFailure()) {
     error() << "Couldn't get THistSvc" << endmsg;
@@ -41,7 +41,7 @@ StatusCode HepMCHistograms::initialize() {
   return StatusCode::SUCCESS;
 }
 
-StatusCode HepMCHistograms::execute() {
+StatusCode HepMCHistograms::execute(const EventContext&) const {
   auto evt = m_hepmchandle.get();
 
   info() << "Processing event with " << evt->particles().size() << " particles" << endmsg;
@@ -60,7 +60,7 @@ StatusCode HepMCHistograms::execute() {
 }
 
 StatusCode HepMCHistograms::finalize() {
-  if (GaudiAlgorithm::finalize().isFailure()) return StatusCode::FAILURE;
+  if (Gaudi::Algorithm::finalize().isFailure()) return StatusCode::FAILURE;
 
   return StatusCode::SUCCESS;
 }

--- a/k4Gen/src/components/HepMCHistograms.h
+++ b/k4Gen/src/components/HepMCHistograms.h
@@ -2,13 +2,13 @@
 #define GENERATION_HEPMCHISTOGRAMS_H
 
 #include "k4FWCore/DataHandle.h"
-#include "GaudiAlg/GaudiAlgorithm.h"
+#include "Gaudi/Algorithm.h"
 #include "GaudiKernel/ITHistSvc.h"
 #include "HepMC3/GenEvent.h"
 
 #include "TH1F.h"
 
-class HepMCHistograms : public GaudiAlgorithm {
+class HepMCHistograms : public Gaudi::Algorithm {
 
 public:
   /// Constructor.
@@ -16,13 +16,13 @@ public:
   /// Initialize.
   virtual StatusCode initialize();
   /// Execute.
-  virtual StatusCode execute();
+  virtual StatusCode execute(const EventContext&) const;
   /// Finalize.
   virtual StatusCode finalize();
 
 private:
   /// Handle for the HepMC to be read
-  DataHandle<HepMC3::GenEvent> m_hepmchandle{"HepMC", Gaudi::DataHandle::Reader, this};
+  mutable DataHandle<HepMC3::GenEvent> m_hepmchandle{"HepMC", Gaudi::DataHandle::Reader, this};
 
   ITHistSvc* m_ths{nullptr};  ///< THistogram service
 

--- a/k4Gen/src/components/HepMCSimpleMerge.cpp
+++ b/k4Gen/src/components/HepMCSimpleMerge.cpp
@@ -11,14 +11,14 @@
 DECLARE_COMPONENT(HepMCSimpleMerge)
 
 HepMCSimpleMerge::HepMCSimpleMerge(const std::string& type, const std::string& name, const IInterface* parent)
-    : GaudiTool(type, name, parent) {
+    : AlgTool(type, name, parent) {
   declareInterface<IHepMCMergeTool>(this);
 }
 
 HepMCSimpleMerge::~HepMCSimpleMerge() {}
 
 StatusCode HepMCSimpleMerge::initialize() {
-  StatusCode sc = GaudiTool::initialize();
+  StatusCode sc = AlgTool::initialize();
   if (!sc.isSuccess()) return sc;
   return sc;
 }
@@ -49,4 +49,4 @@ StatusCode HepMCSimpleMerge::merge(HepMC3::GenEvent& signalEvent, const std::vec
   return StatusCode::SUCCESS;
 }
 
-StatusCode HepMCSimpleMerge::finalize() { return GaudiTool::finalize(); }
+StatusCode HepMCSimpleMerge::finalize() { return AlgTool::finalize(); }

--- a/k4Gen/src/components/HepMCSimpleMerge.h
+++ b/k4Gen/src/components/HepMCSimpleMerge.h
@@ -5,11 +5,11 @@
 #include "k4FWCore/DataHandle.h"
 #include "Generation/IHepMCMergeTool.h"
 
-#include "GaudiAlg/GaudiTool.h"
+#include "GaudiKernel/AlgTool.h"
 #include "GaudiKernel/RndmGenerators.h"
 
 
-class HepMCSimpleMerge final: public GaudiTool, virtual public IHepMCMergeTool {
+class HepMCSimpleMerge final: public AlgTool, virtual public IHepMCMergeTool {
 public:
   HepMCSimpleMerge(const std::string& type, const std::string& name, const IInterface* parent);
 

--- a/k4Gen/src/components/HepMCToEDMConverter.cpp
+++ b/k4Gen/src/components/HepMCToEDMConverter.cpp
@@ -7,7 +7,7 @@
 DECLARE_COMPONENT(HepMCToEDMConverter)
 
 
-edm4hep::MutableMCParticle HepMCToEDMConverter::convert(std::shared_ptr<const HepMC3::GenParticle> hepmcParticle) {
+edm4hep::MutableMCParticle HepMCToEDMConverter::convert(std::shared_ptr<const HepMC3::GenParticle> hepmcParticle) const {
   edm4hep::MutableMCParticle edm_particle;
   edm_particle.setPDG(hepmcParticle->pdg_id());
   edm_particle.setGeneratorStatus(hepmcParticle->status());

--- a/k4Gen/src/components/HepMCToEDMConverter.cpp
+++ b/k4Gen/src/components/HepMCToEDMConverter.cpp
@@ -43,16 +43,16 @@ edm4hep::MutableMCParticle HepMCToEDMConverter::convert(std::shared_ptr<const He
   return edm_particle;
 }
 
-HepMCToEDMConverter::HepMCToEDMConverter(const std::string& name, ISvcLocator* svcLoc) : GaudiAlgorithm(name, svcLoc) {
+HepMCToEDMConverter::HepMCToEDMConverter(const std::string& name, ISvcLocator* svcLoc) : Gaudi::Algorithm(name, svcLoc) {
   declareProperty("hepmc", m_hepmchandle, "HepMC event handle (input)");
   declareProperty("GenParticles", m_genphandle, "Generated particles collection (output)");
 }
 
 StatusCode HepMCToEDMConverter::initialize() { 
-  return GaudiAlgorithm::initialize();
+  return Gaudi::Algorithm::initialize();
 }
 
-StatusCode HepMCToEDMConverter::execute() {
+StatusCode HepMCToEDMConverter::execute(const EventContext&) const {
   const HepMC3::GenEvent* evt = m_hepmchandle.get();
   edm4hep::MCParticleCollection* particles = new edm4hep::MCParticleCollection();
 
@@ -94,5 +94,5 @@ StatusCode HepMCToEDMConverter::execute() {
 }
 
 StatusCode HepMCToEDMConverter::finalize() {
-   return GaudiAlgorithm::finalize();
+   return Gaudi::Algorithm::finalize();
 }

--- a/k4Gen/src/components/HepMCToEDMConverter.h
+++ b/k4Gen/src/components/HepMCToEDMConverter.h
@@ -2,7 +2,7 @@
 #define GENERATION_HEPMCTOEDMCONVERTER_H
 
 #include "k4FWCore/DataHandle.h"
-#include "GaudiAlg/GaudiAlgorithm.h"
+#include "Gaudi/Algorithm.h"
 #include "HepMC3/GenEvent.h"
 #include "HepMC3/GenParticle.h"
 #include "HepMC3/GenVertex.h"
@@ -14,7 +14,7 @@ class MCParticle;
 class MutableMCParticle;
 }
 
-class HepMCToEDMConverter : public GaudiAlgorithm {
+class HepMCToEDMConverter : public Gaudi::Algorithm {
 
 public:
   /// Constructor.
@@ -22,7 +22,7 @@ public:
   /// Initialize.
   virtual StatusCode initialize();
   /// Execute.
-  virtual StatusCode execute();
+  virtual StatusCode execute(const EventContext&) const;
   /// Finalize.
   virtual StatusCode finalize();
 
@@ -31,9 +31,9 @@ private:
   /// If emtpy, all particles will be converted. 
   Gaudi::Property<std::vector<unsigned int>> m_hepmcStatusList{this, "hepmcStatusList", {1}, "list of hepmc statuses to keep. An empty list means all statuses will be kept"};
   /// Handle for the HepMC to be read
-  DataHandle<HepMC3::GenEvent> m_hepmchandle{"hepmc", Gaudi::DataHandle::Reader, this};
+  mutable DataHandle<HepMC3::GenEvent> m_hepmchandle{"hepmc", Gaudi::DataHandle::Reader, this};
   /// Handle for the genparticles to be written
-  DataHandle<edm4hep::MCParticleCollection> m_genphandle{"GenParticles", Gaudi::DataHandle::Writer, this};
+  mutable DataHandle<edm4hep::MCParticleCollection> m_genphandle{"GenParticles", Gaudi::DataHandle::Writer, this};
 
   edm4hep::MutableMCParticle convert(std::shared_ptr<const HepMC3::GenParticle> hepmcParticle);
 };

--- a/k4Gen/src/components/HepMCToEDMConverter.h
+++ b/k4Gen/src/components/HepMCToEDMConverter.h
@@ -35,6 +35,6 @@ private:
   /// Handle for the genparticles to be written
   mutable DataHandle<edm4hep::MCParticleCollection> m_genphandle{"GenParticles", Gaudi::DataHandle::Writer, this};
 
-  edm4hep::MutableMCParticle convert(std::shared_ptr<const HepMC3::GenParticle> hepmcParticle);
+  edm4hep::MutableMCParticle convert(std::shared_ptr<const HepMC3::GenParticle> hepmcParticle) const;
 };
 #endif

--- a/k4Gen/src/components/MDIReader.cpp
+++ b/k4Gen/src/components/MDIReader.cpp
@@ -14,7 +14,7 @@
 DECLARE_COMPONENT(MDIReader)
 
 MDIReader::MDIReader(const std::string& name, ISvcLocator* svcLoc):
-GaudiAlgorithm(name, svcLoc),
+Gaudi::Algorithm(name, svcLoc),
   m_filename() {
 
   declareProperty("MDIFilename", m_filename="", "Name of the MDI file to read");
@@ -27,7 +27,7 @@ GaudiAlgorithm(name, svcLoc),
 
 StatusCode MDIReader::initialize()
 {
-  StatusCode sc = GaudiAlgorithm::initialize();
+  StatusCode sc = Gaudi::Algorithm::initialize();
 
   debug() << "Reading file: " << m_filename << endmsg;
 
@@ -40,7 +40,7 @@ StatusCode MDIReader::initialize()
   return StatusCode::SUCCESS;
 }
 
-StatusCode MDIReader::execute()
+StatusCode MDIReader::execute(const EventContext&) const
 {
   // First check the input file status
   if(m_input.eof())
@@ -224,5 +224,5 @@ StatusCode MDIReader::finalize()
 {
   m_input.close();
   debug() << "MDIReader finalization" << endmsg;
-  return GaudiAlgorithm::finalize();
+  return Gaudi::Algorithm::finalize();
 }

--- a/k4Gen/src/components/MDIReader.h
+++ b/k4Gen/src/components/MDIReader.h
@@ -44,7 +44,7 @@ public:
 private:
 
   std::string m_filename;
-  std::ifstream m_input;
+  mutable std::ifstream m_input;
   int NHEP;
   int m_format;
   std::string input_type;

--- a/k4Gen/src/components/MDIReader.h
+++ b/k4Gen/src/components/MDIReader.h
@@ -8,7 +8,7 @@
 
 #include "k4FWCore/DataHandle.h"
 
-#include "GaudiAlg/GaudiAlgorithm.h"
+#include "Gaudi/Algorithm.h"
 #include "GaudiKernel/ToolHandle.h"
 
 #include "GaudiKernel/SystemOfUnits.h"
@@ -29,7 +29,7 @@ class MCParticleCollection;
  *  @version 1.0
  */
 
-class MDIReader: public GaudiAlgorithm {
+class MDIReader: public Gaudi::Algorithm {
 
 public:
   /// Constructor.
@@ -37,7 +37,7 @@ public:
   /// Initialize.
   virtual StatusCode initialize();
   /// Execute.
-  virtual StatusCode execute();
+  virtual StatusCode execute(const EventContext&) const;
   /// Finalize.
   virtual StatusCode finalize();
 
@@ -50,7 +50,7 @@ private:
   std::string input_type;
   double xing, cut_z, beam_energy;
   /// Handle for the genparticles to be written
-  DataHandle<edm4hep::MCParticleCollection> m_genphandle {"GenParticles", Gaudi::DataHandle::Writer, this};
+  mutable DataHandle<edm4hep::MCParticleCollection> m_genphandle {"GenParticles", Gaudi::DataHandle::Writer, this};
 
 
   /// Tools to handle input from HepMC-file

--- a/k4Gen/src/components/MomentumRangeParticleGun.cpp
+++ b/k4Gen/src/components/MomentumRangeParticleGun.cpp
@@ -32,14 +32,19 @@ StatusCode MomentumRangeParticleGun::initialize() {
 
   IRndmGenSvc* randSvc = svc<IRndmGenSvc>("RndmGenSvc", true);
   sc = m_flatGenerator.initialize(randSvc, Rndm::Flat(0., 1.));
-  if (!sc.isSuccess()) return Error("Cannot initialize flat generator");
+  if (!sc.isSuccess()) {
+    error() << "Cannot initialize flat generator";
+    return StatusCode::FAILURE;
+  }
 
   // Get the mass of the particle to be generated
   //
 
   // check momentum and angles
-  if ((m_minMom > m_maxMom) || (m_minTheta > m_maxTheta) || (m_minPhi > m_maxPhi))
-    return Error("Incorrect values for momentum, theta or phi!");
+  if ((m_minMom > m_maxMom) || (m_minTheta > m_maxTheta) || (m_minPhi > m_maxPhi)) {
+    error() << "Incorrect values for momentum, theta or phi!" << endmsg;
+    return StatusCode::FAILURE;
+  }
 
   m_deltaMom = m_maxMom - m_minMom;
   m_deltaPhi = m_maxPhi - m_minPhi;

--- a/k4Gen/src/components/MomentumRangeParticleGun.cpp
+++ b/k4Gen/src/components/MomentumRangeParticleGun.cpp
@@ -18,7 +18,7 @@ DECLARE_COMPONENT(MomentumRangeParticleGun)
 MomentumRangeParticleGun::MomentumRangeParticleGun(const std::string& type,
                                                    const std::string& name,
                                                    const IInterface* parent)
-    : GaudiTool(type, name, parent) {
+    : AlgTool(type, name, parent) {
   declareInterface<IParticleGunTool>(this);
 }
 
@@ -27,7 +27,7 @@ MomentumRangeParticleGun::~MomentumRangeParticleGun() {}
 
 /// Initialize Particle Gun parameters
 StatusCode MomentumRangeParticleGun::initialize() {
-  StatusCode sc = GaudiTool::initialize();
+  StatusCode sc = AlgTool::initialize();
   if (!sc.isSuccess()) return sc;
 
   IRndmGenSvc* randSvc = svc<IRndmGenSvc>("RndmGenSvc", true);

--- a/k4Gen/src/components/MomentumRangeParticleGun.cpp
+++ b/k4Gen/src/components/MomentumRangeParticleGun.cpp
@@ -30,7 +30,7 @@ StatusCode MomentumRangeParticleGun::initialize() {
   StatusCode sc = AlgTool::initialize();
   if (!sc.isSuccess()) return sc;
 
-  IRndmGenSvc* randSvc = svc<IRndmGenSvc>("RndmGenSvc", true);
+  IRndmGenSvc* randSvc = service<IRndmGenSvc>("RndmGenSvc", true);
   sc = m_flatGenerator.initialize(randSvc, Rndm::Flat(0., 1.));
   if (!sc.isSuccess()) {
     error() << "Cannot initialize flat generator";

--- a/k4Gen/src/components/MomentumRangeParticleGun.h
+++ b/k4Gen/src/components/MomentumRangeParticleGun.h
@@ -1,7 +1,7 @@
 #ifndef GENERATION_MOMENTUMRANGEPARTICLEGUN_H
 #define GENERATION_MOMENTUMRANGEPARTICLEGUN_H
 
-#include "GaudiAlg/GaudiTool.h"
+#include "GaudiKernel/AlgTool.h"
 #include "GaudiKernel/PhysicalConstants.h"
 #include "GaudiKernel/RndmGenerators.h"
 #include "GaudiKernel/SystemOfUnits.h"
@@ -17,7 +17,7 @@
  *  @author Valentin Volkl (rewrite as tool)
  *  @date   2008-05-18
  */
-class MomentumRangeParticleGun : public GaudiTool, virtual public IParticleGunTool {
+class MomentumRangeParticleGun : public AlgTool, virtual public IParticleGunTool {
 
 public:
   /// Constructor

--- a/k4Gen/src/components/PoissonPileUp.cpp
+++ b/k4Gen/src/components/PoissonPileUp.cpp
@@ -14,9 +14,15 @@ StatusCode PoissonPileUp::initialize() {
   StatusCode sc = AlgTool::initialize();
   if (sc.isFailure()) return sc;
   IRndmGenSvc* randSvc = svc<IRndmGenSvc>("RndmGenSvc", true);
-  if (m_meanPileUpEvents < 0) return Error("Number of Pileup events cannot be negative!");
+  if (m_meanPileUpEvents < 0) {
+    error() << "Number of Pileup events cannot be negative!";
+    return StatusCode::FAILURE;
+  }
   sc = m_PoissonDist.initialize(randSvc, Rndm::Poisson(m_meanPileUpEvents));
-  if (!sc.isSuccess()) return Error("Could not initialize Poisson random number generator");
+  if (!sc.isSuccess()) {
+    error() << "Could not initialize Poisson random number generator";
+    return StatusCode::FAILURE;
+  }
   release(randSvc).ignore();
   m_currentNumPileUpEvents = m_PoissonDist();
   printPileUpCounters();

--- a/k4Gen/src/components/PoissonPileUp.cpp
+++ b/k4Gen/src/components/PoissonPileUp.cpp
@@ -13,7 +13,7 @@ PoissonPileUp::~PoissonPileUp() { ; }
 StatusCode PoissonPileUp::initialize() {
   StatusCode sc = AlgTool::initialize();
   if (sc.isFailure()) return sc;
-  IRndmGenSvc* randSvc = svc<IRndmGenSvc>("RndmGenSvc", true);
+  IRndmGenSvc* randSvc = service<IRndmGenSvc>("RndmGenSvc", true);
   if (m_meanPileUpEvents < 0) {
     error() << "Number of Pileup events cannot be negative!";
     return StatusCode::FAILURE;

--- a/k4Gen/src/components/PoissonPileUp.cpp
+++ b/k4Gen/src/components/PoissonPileUp.cpp
@@ -23,7 +23,6 @@ StatusCode PoissonPileUp::initialize() {
     error() << "Could not initialize Poisson random number generator";
     return StatusCode::FAILURE;
   }
-  release(randSvc).ignore();
   m_currentNumPileUpEvents = m_PoissonDist();
   printPileUpCounters();
   return sc;

--- a/k4Gen/src/components/PoissonPileUp.cpp
+++ b/k4Gen/src/components/PoissonPileUp.cpp
@@ -4,14 +4,14 @@
 DECLARE_COMPONENT(PoissonPileUp)
 
 PoissonPileUp::PoissonPileUp(const std::string& type, const std::string& name, const IInterface* parent)
-    : GaudiTool(type, name, parent) {
+    : AlgTool(type, name, parent) {
   declareInterface<IPileUpTool>(this);
 }
 
 PoissonPileUp::~PoissonPileUp() { ; }
 
 StatusCode PoissonPileUp::initialize() {
-  StatusCode sc = GaudiTool::initialize();
+  StatusCode sc = AlgTool::initialize();
   if (sc.isFailure()) return sc;
   IRndmGenSvc* randSvc = svc<IRndmGenSvc>("RndmGenSvc", true);
   if (m_meanPileUpEvents < 0) return Error("Number of Pileup events cannot be negative!");

--- a/k4Gen/src/components/PoissonPileUp.h
+++ b/k4Gen/src/components/PoissonPileUp.h
@@ -2,7 +2,7 @@
 #define GENERATION_POISSONPILEUP_H
 
 #include "Generation/IPileUpTool.h"
-#include "GaudiAlg/GaudiTool.h"
+#include "GaudiKernel/AlgTool.h"
 #include "GaudiKernel/RndmGenerators.h"
 
 /** @class PoissonPileUp 
@@ -15,7 +15,7 @@
  *  @author Valentin Volkl
  *  @date   2016-01-18
  */
-class PoissonPileUp : public GaudiTool, virtual public IPileUpTool {
+class PoissonPileUp : public AlgTool, virtual public IPileUpTool {
 public:
   PoissonPileUp(const std::string& type, const std::string& name, const IInterface* parent);
   virtual ~PoissonPileUp();

--- a/k4Gen/src/components/PythiaInterface.cpp
+++ b/k4Gen/src/components/PythiaInterface.cpp
@@ -17,7 +17,7 @@
 DECLARE_COMPONENT(PythiaInterface)
 
 PythiaInterface::PythiaInterface(const std::string& type, const std::string& name, const IInterface* parent)
-    : GaudiTool(type, name, parent),
+    : AlgTool(type, name, parent),
       m_pythiaSignal(nullptr),
       m_nAbort(0),
       m_iAbort(0),
@@ -33,7 +33,7 @@ PythiaInterface::PythiaInterface(const std::string& type, const std::string& nam
 
 StatusCode PythiaInterface::initialize() {
 
-  StatusCode sc = GaudiTool::initialize();
+  StatusCode sc = AlgTool::initialize();
   if (!sc.isSuccess()) return sc;
   if (m_pythiacard.empty() && m_pythia_extrasettings.size() < 2) {
     return Error("Define Pythia8 configuration file (*.cmd)!");
@@ -395,5 +395,5 @@ StatusCode PythiaInterface::finalize() {
   if (nullptr != m_evtgen) {
      delete m_evtgen;
   }
-  return GaudiTool::finalize();
+  return AlgTool::finalize();
 }

--- a/k4Gen/src/components/PythiaInterface.cpp
+++ b/k4Gen/src/components/PythiaInterface.cpp
@@ -36,7 +36,8 @@ StatusCode PythiaInterface::initialize() {
   StatusCode sc = AlgTool::initialize();
   if (!sc.isSuccess()) return sc;
   if (m_pythiacard.empty() && m_pythia_extrasettings.size() < 2) {
-    return Error("Define Pythia8 configuration file (*.cmd)!");
+    error() << "No Pythia8 configuration file (*.cmd) defined!" << endmsg;
+    return StatusCode::FAILURE;
   }
 
   // Set Pythia configuration directory from system variable (if set)
@@ -82,7 +83,8 @@ StatusCode PythiaInterface::initialize() {
 
   // Currently, only one scheme at a time is allowed.
   if (m_doMePsMerging && m_doMePsMatching) {
-    return Error("Jet matching and merging cannot be used simultaneously!");
+    error() << "Jet matching and merging cannot be used simultaneously!" << endmsg;
+    return StatusCode::FAILURE;
   }
 
   // Allow to set the number of additional partons dynamically.
@@ -112,7 +114,8 @@ StatusCode PythiaInterface::initialize() {
   if (m_doMePsMatching) {
     m_matching = std::unique_ptr<Pythia8::JetMatchingMadgraph>(new Pythia8::JetMatchingMadgraph());
     if (!m_matching) {
-      return Error(" Failed to initialise jet matching structures.");
+      error() << "Failed to initialise jet matching structures." << endmsg;
+      return StatusCode::FAILURE;
     }
     #if PYTHIA_VERSION_INTEGER < 8300
     m_pythiaSignal->setUserHooksPtr(m_matching.get());
@@ -220,7 +223,8 @@ StatusCode PythiaInterface::getNextEvent(HepMC3::GenEvent& theEvent) {
       IIncidentSvc* incidentSvc;
       StatusCode sc = service("IncidentSvc", incidentSvc);
       incidentSvc->fireIncident(Incident(name(), IncidentType::AbortEvent));
-      return Error("Event generation aborted prematurely, owing to error!");
+      error() << "Event generation aborted prematurely, owing to error!" << endmsg;
+      return StatusCode::FAILURE;
     } else {
       warning() << "PythiaInterface Pythia8 abort : " << m_iAbort << "/" << m_nAbort << std::endl;
     }

--- a/k4Gen/src/components/PythiaInterface.h
+++ b/k4Gen/src/components/PythiaInterface.h
@@ -3,7 +3,7 @@
 
 #include <memory>
 #include "k4FWCore/DataHandle.h"
-#include "GaudiAlg/GaudiTool.h"
+#include "GaudiKernel/AlgTool.h"
 #include "Generation/IHepMCProviderTool.h"
 #include "Generation/IVertexSmearingTool.h"
 #include "ResonanceDecayFilterHook.h"
@@ -36,7 +36,7 @@ class amcnlo_unitarised_interface;
 #endif
 
 
-class PythiaInterface : public GaudiTool, virtual public IHepMCProviderTool {
+class PythiaInterface : public AlgTool, virtual public IHepMCProviderTool {
 
 public:
   /// Constructor.
@@ -61,7 +61,7 @@ private:
   // Tool to smear vertices
   ToolHandle<IVertexSmearingTool> m_vertexSmearingTool;
   // Output handle for ME/PS matching variables
-  DataHandle<std::vector<float>> m_handleMePsMatchingVars{"mePsMatchingVars", Gaudi::DataHandle::Writer, this};
+  mutable DataHandle<std::vector<float>> m_handleMePsMatchingVars{"mePsMatchingVars", Gaudi::DataHandle::Writer, this};
 
   int m_nAbort{0};
   int m_iAbort{0};

--- a/k4Gen/src/components/RangePileUp.cpp
+++ b/k4Gen/src/components/RangePileUp.cpp
@@ -3,14 +3,14 @@
 DECLARE_COMPONENT(RangePileUp)
 
 RangePileUp::RangePileUp(const std::string& type, const std::string& name, const IInterface* parent)
-    : GaudiTool(type, name, parent) {
+    : AlgTool(type, name, parent) {
   declareInterface<IPileUpTool>(this);
 }
 
 RangePileUp::~RangePileUp() { ; }
 
 StatusCode RangePileUp::initialize() {
-  StatusCode sc = GaudiTool::initialize();
+  StatusCode sc = AlgTool::initialize();
   if (sc.isFailure()) return sc;
   return sc;
 }

--- a/k4Gen/src/components/RangePileUp.h
+++ b/k4Gen/src/components/RangePileUp.h
@@ -2,7 +2,7 @@
 #define GENERATION_RANGEPILEUP_H
 
 #include "Generation/IPileUpTool.h"
-#include "GaudiAlg/GaudiTool.h"
+#include "GaudiKernel/AlgTool.h"
 
 /** @class RangePileUp 
  *
@@ -14,7 +14,7 @@
  *  @author Valentin Volkl
  *  @date   2016-01-18
  */
-class RangePileUp : public GaudiTool, virtual public IPileUpTool {
+class RangePileUp : public AlgTool, virtual public IPileUpTool {
 public:
   RangePileUp(const std::string& type, const std::string& name, const IInterface* parent);
   virtual ~RangePileUp();


### PR DESCRIPTION
These are the changes needed not to use GaudiAlg, which will be removed (maybe soon) in Gaudi.

Changes:
- Do not link to GaudiAlgLib
- Add the necessary changes to the algorithm, use `Gaudi::Algorithm`, make `execute()` const and add a `const EventContext&`
- Add mutable to some elements that are changed; add const to some functions so that they can be called inside `execute(const EventContext&) const`
- Change `GaudiTool` to `AlgTool`