### PR TITLE
Use std::shared_ptr for compatibility with HepMC3 3.3.0

### DIFF
--- a/k4Gen/src/components/EDMToHepMCConverter.cpp
+++ b/k4Gen/src/components/EDMToHepMCConverter.cpp
@@ -27,20 +27,19 @@ StatusCode EDMToHepMCConverter::execute(const EventContext&) const {
   event->set_units(HepMC3::Units::GEV, HepMC3::Units::MM);
 
 
-  for (auto p : *(particles)) {
+  for (auto p : *particles) {
     if (p.getGeneratorStatus() == 1) {  // only final state particles
       const auto& mom = p.getMomentum();
-      auto* pHepMC =
-          new GenParticle(HepMC3::FourVector(mom.x, mom.y, mom.z, p.getMass()),
-                          p.getPDG(),
-                          p.getGeneratorStatus());  // hepmc status code for final state particle
+      auto pHepMC = std::make_shared<GenParticle>(HepMC3::FourVector(mom.x, mom.y, mom.z, p.getMass()),
+                                                  p.getPDG(),
+                                                  p.getGeneratorStatus());  // hepmc status code for final state particle
 
         const auto& pos = p.getVertex();
-        auto* v =
-            new HepMC3::GenVertex(HepMC3::FourVector(pos.x,
-                                                   pos.y,
-                                                   pos.z,
-                                                   p.getTime() / Gaudi::Units::c_light));
+        auto v =
+            std::make_shared<HepMC3::GenVertex>(HepMC3::FourVector(pos.x,
+                                                                   pos.y,
+                                                                   pos.z,
+                                                                   p.getTime() / Gaudi::Units::c_light));
 
         v->add_particle_out(pHepMC);
         event->add_vertex(v);

--- a/k4Gen/src/components/HepMCFullMerge.cpp
+++ b/k4Gen/src/components/HepMCFullMerge.cpp
@@ -26,21 +26,21 @@ StatusCode HepMCFullMerge::initialize() {
 StatusCode HepMCFullMerge::merge(HepMC3::GenEvent& signalEvent, const std::vector<HepMC3::GenEvent>& eventVector) {
   for (auto it = eventVector.cbegin(), end = eventVector.cend(); it != end; ++it) {
     // keep track of which vertex in full event corresponds to which vertex in merged event
-    std::unordered_map<const HepMC3::GenVertex*, HepMC3::GenVertex*> inputToMergedVertexMap;
-    for (auto v: (*it).vertices()) {
-      HepMC3::GenVertex* outvertex = new HepMC3::GenVertex(v->position());
-      inputToMergedVertexMap[v.get()] = outvertex;
+    std::unordered_map<std::shared_ptr<const HepMC3::GenVertex>, std::shared_ptr<HepMC3::GenVertex>> inputToMergedVertexMap;
+    for (auto& v: it->vertices()) {
+      auto outvertex = std::make_shared<HepMC3::GenVertex>(v->position());
+      inputToMergedVertexMap[v] = outvertex;
       signalEvent.add_vertex(outvertex);
     }
-    for (auto p: (*it).particles()) {
+    for (auto& p: it->particles()) {
       // ownership of the particle is given to the vertex
-      HepMC3::GenParticle* newparticle = new HepMC3::GenParticle(*p);
+      auto newparticle = std::make_shared<HepMC3::GenParticle>(*p);
       // attach particles to correct vertices in merged event
-      if (nullptr != p->end_vertex()) {
-        inputToMergedVertexMap[p->end_vertex().get()]->add_particle_in(newparticle);
+      if (p->end_vertex()) {
+        inputToMergedVertexMap[p->end_vertex()]->add_particle_in(newparticle);
       }
-      if (nullptr != p->production_vertex()) {
-        inputToMergedVertexMap[p->production_vertex().get()]->add_particle_out(newparticle);
+      if (p->production_vertex()) {
+        inputToMergedVertexMap[p->production_vertex()]->add_particle_out(newparticle);
       }
     }
   }


### PR DESCRIPTION
BEGINRELEASENOTES
- Use `std::shared_ptr` for compatibility with HepMC3 3.3.0. This is needed after https://gitlab.cern.ch/hepmc/HepMC3/-/merge_requests/247 and https://gitlab.cern.ch/hepmc/HepMC3/-/merge_requests/342 which appear in 3.3.0 for the first time.

ENDRELEASENOTES

Compiling and tests work fine for me with HepMC3 3.3.0. I would need this PR merged to complete the nightly builds.
