### PR TITLE
Add REQUIRED in find_package

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,9 +12,9 @@ endif()
 
 #- Dependencies ------------------------------------------------
 find_package(ROOT COMPONENTS RIO Tree)
-find_package(Gaudi)
-find_package(k4FWCore)
-find_package(EDM4HEP)
+find_package(Gaudi REQUIRED)
+find_package(k4FWCore REQUIRED)
+find_package(EDM4HEP REQUIRED)
 
 # use FindHEPPDT from Gaudi (used when finding heppdt later)
 set(CMAKE_MODULE_PATH ${Gaudi_LIBRARY_DIR}/cmake/Gaudi/modules ${CMAKE_MODULE_PATH})

--- a/k4Gen/CMakeLists.txt
+++ b/k4Gen/CMakeLists.txt
@@ -2,10 +2,10 @@
 # Package: k4Gen
 ################################################################################
 
-find_package(HepMC3)
+find_package(HepMC3 REQUIRED)
 find_package(Pythia8 COMPONENTS pythia8 pythia8tohepmc)
-find_package(HepPDT)
-find_package(EvtGen)
+find_package(HepPDT REQUIRED)
+find_package(EvtGen REQUIRED)
 
 file(GLOB k4gen_plugin_sources src/components/*.cpp)
 gaudi_add_module(k4Gen

--- a/k4Gen/src/components/GenEventFilter.h
+++ b/k4Gen/src/components/GenEventFilter.h
@@ -42,7 +42,7 @@ private:
       "particles", Gaudi::DataHandle::Reader, this};
   /// Writes out filter statistics.
   MetaDataHandle<std::vector<int>> m_evtFilterStats{
-    edm4hep::EventFilterStats, Gaudi::DataHandle::Writer};
+    edm4hep::labels::EventFilterStats, Gaudi::DataHandle::Writer};
 
   /// Rule to filter the events with.
   Gaudi::Property<std::string> m_filterRuleStr{


### PR DESCRIPTION
These packages are required for compilation, so `find_package` should already require them. Also fix a deprecation warning.