### PR TITLE
Fix the arguments for a test

### DIFF
--- a/k4Gen/CMakeLists.txt
+++ b/k4Gen/CMakeLists.txt
@@ -67,7 +67,7 @@ set_test_env(Pythia8Default)
 
 add_test(NAME Pythia8ExtraSettings
                WORKING_DIRECTORY ${CMAKE_CURRENT_LIST_DIR}
-               COMMAND  k4run ${CMAKE_CURRENT_LIST_DIR}/options/pythia.py  --pythiaExtraSettings "Beams:idA = 13" "Beams:idB = -13"
+               COMMAND  k4run ${CMAKE_CURRENT_LIST_DIR}/options/pythia.py --pythiaExtraSettings.Pythia8.PythiaInterface "Beams:idA = 13" "Beams:idB = -13"
               )
 set_tests_properties(Pythia8ExtraSettings PROPERTIES
   PASS_REGULAR_EXPRESSION "We collide mu- with mu"


### PR DESCRIPTION
I'm not sure why this stopped working but when running one of the tests we get:

``` 
k4run: error: ambiguous option: --pythiaExtraSettings could match --pythiaExtraSettings.ToolSvc.PythiaInterface, --pythiaExtraSettings.Pythia8.PythiaInterface
```

And it makes sense that --pythiaExtraSettings can not be a global option. I'm not sure when this worked, or if it has been any changes (https://github.com/key4hep/k4FWCore/pull/242?) that modified how this works. Now the next question is why does `--pythiaExtraSettings.ToolSvc.PythiaInterface` appear, which won't change the value of `pythiaExtraSettings` and is a duplicated of the "good" one.