### PR TITLE
Link with ROOT::Hist since TH1F is being used

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,7 +11,7 @@ if(USE_RUNPATH_INSTEAD_OF_RPATH)
 endif()
 
 #- Dependencies ------------------------------------------------
-find_package(ROOT COMPONENTS RIO Tree)
+find_package(ROOT COMPONENTS RIO Tree Hist)
 find_package(Gaudi REQUIRED)
 find_package(k4FWCore REQUIRED)
 find_package(EDM4HEP REQUIRED)

--- a/k4Gen/CMakeLists.txt
+++ b/k4Gen/CMakeLists.txt
@@ -17,6 +17,7 @@ gaudi_add_module(k4Gen
                       EvtGen::EvtGen
                       EvtGen::EvtGenExternal
                       EDM4HEP::edm4hep
+                      ROOT::Hist
                       )
 
 target_include_directories(k4Gen PUBLIC ${PYTHIA8_INCLUDE_DIRS} 


### PR DESCRIPTION
This is needed for builds on MacOS, otherwise it will fail with the error
```
Undefined symbols for architecture arm64:
 "TH1F::TH1F(char const, char const, int, double, double)", referenced from:
      HepMCHistograms::initialize() in HepMCHistograms.cpp.o
      HepMCHistograms::initialize() in HepMCHistograms.cpp.o
      HepMCHistograms::initialize() in HepMCHistograms.cpp.o
      HepMCHistograms::initialize() in HepMCHistograms.cpp.o
```