### PR TITLE
Move DataHandle and MetaDataHandle to the k4FWCore namespace

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@ project(k4Gen LANGUAGES CXX)
 #- Dependencies ------------------------------------------------
 find_package(ROOT COMPONENTS RIO Tree Hist)
 find_package(Gaudi REQUIRED)
-find_package(k4FWCore REQUIRED)
+find_package(k4FWCore 1.3 REQUIRED)
 find_package(EDM4HEP REQUIRED)
 
 include(cmake/Key4hepConfig.cmake)

--- a/k4Gen/src/components/EDMToHepMCConverter.h
+++ b/k4Gen/src/components/EDMToHepMCConverter.h
@@ -24,9 +24,9 @@ public:
 
 private:
   /// Handle for the HepMC to be read
-  mutable DataHandle<HepMC3::GenEvent> m_hepmchandle{"hepmc", Gaudi::DataHandle::Writer, this};
+  mutable k4FWCore::DataHandle<HepMC3::GenEvent> m_hepmchandle{"hepmc", Gaudi::DataHandle::Writer, this};
   /// Handle for the genparticles to be written
-  mutable DataHandle<edm4hep::MCParticleCollection> m_genphandle{"GenParticles", Gaudi::DataHandle::Reader, this};
+  mutable k4FWCore::DataHandle<edm4hep::MCParticleCollection> m_genphandle{"GenParticles", Gaudi::DataHandle::Reader, this};
 };
 
 #endif

--- a/k4Gen/src/components/GenAlg.h
+++ b/k4Gen/src/components/GenAlg.h
@@ -42,7 +42,7 @@ private:
   /// Tool to merge HepMC events
   mutable ToolHandle<IHepMCMergeTool> m_hepmcMergeTool{"HepMCSimpleMerge/HepMCMergeTool", this};
   // Output handle for finished event
-  mutable DataHandle<HepMC3::GenEvent> m_hepmcHandle{"hepmc", Gaudi::DataHandle::Writer, this};
+  mutable k4FWCore::DataHandle<HepMC3::GenEvent> m_hepmcHandle{"hepmc", Gaudi::DataHandle::Writer, this};
 };
 
 #endif // GENERATION_GENALG_H

--- a/k4Gen/src/components/GenEventFilter.h
+++ b/k4Gen/src/components/GenEventFilter.h
@@ -37,9 +37,9 @@ public:
 
 private:
   /// Handle for the MCParticle collection to be read.
-  mutable DataHandle<edm4hep::MCParticleCollection> m_inColl{"particles", Gaudi::DataHandle::Reader, this};
+  mutable k4FWCore::DataHandle<edm4hep::MCParticleCollection> m_inColl{"particles", Gaudi::DataHandle::Reader, this};
   /// Writes out filter statistics.
-  MetaDataHandle<std::vector<int>> m_evtFilterStats{edm4hep::labels::EventFilterStats, Gaudi::DataHandle::Writer};
+  k4FWCore::MetaDataHandle<std::vector<int>> m_evtFilterStats{edm4hep::labels::EventFilterStats, Gaudi::DataHandle::Writer};
 
   /// Rule to filter the events with.
   Gaudi::Property<std::string> m_filterRuleStr{this, "filterRule", "", "Filter rule to apply on the events"};

--- a/k4Gen/src/components/GenParticleFilter.h
+++ b/k4Gen/src/components/GenParticleFilter.h
@@ -34,9 +34,9 @@ private:
   /// Particle statuses to accept
   Gaudi::Property<std::vector<int>> m_accept{this, "accept", {1}, "Particle statuses to accept"};
   /// Handle for the ParticleCollection to be read
-  mutable DataHandle<edm4hep::MCParticleCollection> m_iGenpHandle{"GenParticles", Gaudi::DataHandle::Reader, this};
+  mutable k4FWCore::DataHandle<edm4hep::MCParticleCollection> m_iGenpHandle{"GenParticles", Gaudi::DataHandle::Reader, this};
   /// Handle for the genparticles to be written
-  mutable DataHandle<edm4hep::MCParticleCollection> m_oGenpHandle{"GenParticlesFiltered", Gaudi::DataHandle::Writer,
+  mutable k4FWCore::DataHandle<edm4hep::MCParticleCollection> m_oGenpHandle{"GenParticlesFiltered", Gaudi::DataHandle::Writer,
                                                                   this};
 };
 

--- a/k4Gen/src/components/HepEVTReader.h
+++ b/k4Gen/src/components/HepEVTReader.h
@@ -45,7 +45,7 @@ private:
   int m_format;
 
   /// Handle for the genparticles to be written
-  mutable DataHandle<edm4hep::MCParticleCollection> m_genphandle{"GenParticles", Gaudi::DataHandle::Writer, this};
+  mutable k4FWCore::DataHandle<edm4hep::MCParticleCollection> m_genphandle{"GenParticles", Gaudi::DataHandle::Writer, this};
 };
 
 #endif // GENERATION_HEPEVTREADER_H

--- a/k4Gen/src/components/HepMC2FileWriter.h
+++ b/k4Gen/src/components/HepMC2FileWriter.h
@@ -34,7 +34,7 @@ public:
 
 private:
   /// Handle for the HepMC to be read
-  mutable DataHandle<HepMC3::GenEvent> m_hepmchandle{"HepMC", Gaudi::DataHandle::Reader, this};
+  mutable k4FWCore::DataHandle<HepMC3::GenEvent> m_hepmchandle{"HepMC", Gaudi::DataHandle::Reader, this};
   Gaudi::Property<std::string> m_filename{this, "Filename", "Output_HepMC.dat", "Name of the HepMC file to write"};
   std::unique_ptr<HepMC3::WriterAsciiHepMC2> m_file;
 };

--- a/k4Gen/src/components/HepMCDumper.h
+++ b/k4Gen/src/components/HepMCDumper.h
@@ -21,7 +21,7 @@ public:
 
 private:
   /// Handle for the HepMC to be read
-  mutable DataHandle<HepMC3::GenEvent> m_hepmchandle{"hepmc", Gaudi::DataHandle::Reader, this};
+  mutable k4FWCore::DataHandle<HepMC3::GenEvent> m_hepmchandle{"hepmc", Gaudi::DataHandle::Reader, this};
 };
 
 #endif // GENERATION_HEPMCDUMPER_H

--- a/k4Gen/src/components/HepMCFileWriter.h
+++ b/k4Gen/src/components/HepMCFileWriter.h
@@ -34,7 +34,7 @@ public:
 
 private:
   /// Handle for the HepMC to be read
-  mutable DataHandle<HepMC3::GenEvent> m_hepmchandle{"HepMC", Gaudi::DataHandle::Reader, this};
+  mutable k4FWCore::DataHandle<HepMC3::GenEvent> m_hepmchandle{"HepMC", Gaudi::DataHandle::Reader, this};
   Gaudi::Property<std::string> m_filename{this, "Filename", "Output_HepMC.dat", "Name of the HepMC file to write"};
   std::unique_ptr<HepMC3::WriterAscii> m_file;
 };

--- a/k4Gen/src/components/HepMCHistograms.h
+++ b/k4Gen/src/components/HepMCHistograms.h
@@ -22,7 +22,7 @@ public:
 
 private:
   /// Handle for the HepMC to be read
-  mutable DataHandle<HepMC3::GenEvent> m_hepmchandle{"HepMC", Gaudi::DataHandle::Reader, this};
+  mutable k4FWCore::DataHandle<HepMC3::GenEvent> m_hepmchandle{"HepMC", Gaudi::DataHandle::Reader, this};
 
   SmartIF<ITHistSvc> m_ths; ///< THistogram service
 

--- a/k4Gen/src/components/HepMCToEDMConverter.h
+++ b/k4Gen/src/components/HepMCToEDMConverter.h
@@ -32,9 +32,9 @@ private:
   Gaudi::Property<std::vector<unsigned int>> m_hepmcStatusList{
       this, "hepmcStatusList", {1}, "list of hepmc statuses to keep. An empty list means all statuses will be kept"};
   /// Handle for the HepMC to be read
-  mutable DataHandle<HepMC3::GenEvent> m_hepmchandle{"hepmc", Gaudi::DataHandle::Reader, this};
+  mutable k4FWCore::DataHandle<HepMC3::GenEvent> m_hepmchandle{"hepmc", Gaudi::DataHandle::Reader, this};
   /// Handle for the genparticles to be written
-  mutable DataHandle<edm4hep::MCParticleCollection> m_genphandle{"GenParticles", Gaudi::DataHandle::Writer, this};
+  mutable k4FWCore::DataHandle<edm4hep::MCParticleCollection> m_genphandle{"GenParticles", Gaudi::DataHandle::Writer, this};
 
   edm4hep::MutableMCParticle convert(std::shared_ptr<const HepMC3::GenParticle> hepmcParticle) const;
 };

--- a/k4Gen/src/components/MDIReader.h
+++ b/k4Gen/src/components/MDIReader.h
@@ -48,7 +48,7 @@ private:
   std::string input_type;
   double xing, cut_z, beam_energy;
   /// Handle for the genparticles to be written
-  mutable DataHandle<edm4hep::MCParticleCollection> m_genphandle{"GenParticles", Gaudi::DataHandle::Writer, this};
+  mutable k4FWCore::DataHandle<edm4hep::MCParticleCollection> m_genphandle{"GenParticles", Gaudi::DataHandle::Writer, this};
 
   /// Tools to handle input from HepMC-file
   ToolHandle<IHepMCFileReaderTool> m_signalFileReader;

--- a/k4Gen/src/components/PythiaInterface.h
+++ b/k4Gen/src/components/PythiaInterface.h
@@ -60,7 +60,7 @@ private:
   /// Pythia8 engine for jet clustering
   std::unique_ptr<Pythia8::SlowJet> m_slowJet{nullptr};
   // Output handle for ME/PS matching variables
-  mutable DataHandle<std::vector<float>> m_handleMePsMatchingVars{"mePsMatchingVars", Gaudi::DataHandle::Writer, this};
+  mutable k4FWCore::DataHandle<std::vector<float>> m_handleMePsMatchingVars{"mePsMatchingVars", Gaudi::DataHandle::Writer, this};
 
   // Maximum number of aborts before giving up
   int m_maxAborts{0};


### PR DESCRIPTION
BEGINRELEASENOTES
- Move DataHandle and MetaDataHandle to the k4FWCore namespace, done in k4FWCore in https://github.com/key4hep/k4FWCore/pull/317
- Bump the required version of k4FWCore

ENDRELEASENOTES