### PR TITLE
Order find_packages such that python requirements are first

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,10 +4,10 @@ CMAKE_MINIMUM_REQUIRED(VERSION 3.15)
 project(k4Gen LANGUAGES CXX)
 
 #- Dependencies ------------------------------------------------
-find_package(ROOT COMPONENTS RIO Tree Hist)
-find_package(Gaudi REQUIRED)
 find_package(k4FWCore 1.3 REQUIRED)
 find_package(EDM4HEP REQUIRED)
+find_package(Gaudi REQUIRED)
+find_package(ROOT COMPONENTS RIO Tree Hist)
 
 include(cmake/Key4hepConfig.cmake)
 


### PR DESCRIPTION
ROOT and Gaudi find any python version, but k4FWCore and EDM4hep will be looking for a specific one which might not be the one found (and cached) by ROOT or Gaudi