### PR TITLE
Only store the spin into MCParticle if it's available

### DIFF
--- a/k4Gen/src/components/HepMCToEDMConverter.cpp
+++ b/k4Gen/src/components/HepMCToEDMConverter.cpp
@@ -22,15 +22,15 @@ HepMCToEDMConverter::convert(std::shared_ptr<const HepMC3::GenParticle> hepmcPar
   edm_particle.setMomentum({p.px(), p.py(), p.pz()});
   edm_particle.setMass(hepmcParticle->generated_mass());
 
-#if EDM4HEP_BUILD_VERSION <= EDM4HEP_VERSION(0, 99, 2)
+#ifdef EDM4HEP_MCPARTICLE_HAS_HELICITY
+  // TODO: Figure out what we want to store here and how to retrieve it from HepMC3
+#else
   // add spin (particle helicity) information if available
   std::shared_ptr<HepMC3::VectorFloatAttribute> spin = hepmcParticle->attribute<HepMC3::VectorFloatAttribute>("spin");
   if (spin) {
     edm4hep::Vector3f hel(spin->value()[0], spin->value()[1], spin->value()[2]);
     edm_particle.setSpin(hel);
   }
-#else
-// TODO: Figure out what we want to store here and how to retrieve it from HepMC3
 #endif
 
   // convert vertex info

--- a/k4Gen/src/components/HepMCToEDMConverter.cpp
+++ b/k4Gen/src/components/HepMCToEDMConverter.cpp
@@ -4,7 +4,6 @@
 // HepPDT
 #include "HepPDT/ParticleID.hh"
 // EDM4hep
-#include "edm4hep/EDM4hepVersion.h"
 #include "edm4hep/MCParticleCollection.h"
 
 DECLARE_COMPONENT(HepMCToEDMConverter)

--- a/k4Gen/src/components/HepMCToEDMConverter.cpp
+++ b/k4Gen/src/components/HepMCToEDMConverter.cpp
@@ -4,6 +4,7 @@
 // HepPDT
 #include "HepPDT/ParticleID.hh"
 // EDM4hep
+#include "edm4hep/EDM4hepVersion.h"
 #include "edm4hep/MCParticleCollection.h"
 
 DECLARE_COMPONENT(HepMCToEDMConverter)
@@ -21,12 +22,16 @@ HepMCToEDMConverter::convert(std::shared_ptr<const HepMC3::GenParticle> hepmcPar
   edm_particle.setMomentum({p.px(), p.py(), p.pz()});
   edm_particle.setMass(hepmcParticle->generated_mass());
 
+#if EDM4HEP_BUILD_VERSION <= EDM4HEP_VERSION(0, 99, 2)
   // add spin (particle helicity) information if available
   std::shared_ptr<HepMC3::VectorFloatAttribute> spin = hepmcParticle->attribute<HepMC3::VectorFloatAttribute>("spin");
   if (spin) {
     edm4hep::Vector3f hel(spin->value()[0], spin->value()[1], spin->value()[2]);
     edm_particle.setSpin(hel);
   }
+#else
+// TODO: Figure out what we want to store here and how to retrieve it from HepMC3
+#endif
 
   // convert vertex info
   auto prodVtx = hepmcParticle->production_vertex();


### PR DESCRIPTION
Only store the spin information into the `edm4hep::MCParticle` as long as that is actually available and not removed / switched to helicity in https://github.com/key4hep/EDM4hep/pull/404

- [ ] Figure out how to retrieve the appropriate information to store in `helicity` from HepMC3. (Similar to https://github.com/key4hep/k4GeneratorsConfig/pull/56)

For now this PR is mainly intended to make it possible to move forward with https://github.com/key4hep/EDM4hep/pull/404 without breaking the nightlies.