### PR TITLE
Use the metadata utilities from k4FWCore instead of MetaDataHandle

### DIFF
--- a/k4Gen/src/components/GenEventFilter.cpp
+++ b/k4Gen/src/components/GenEventFilter.cpp
@@ -1,5 +1,7 @@
 #include "GenEventFilter.h"
 
+#include "k4FWCore/MetadataUtils.h"
+
 // Gaudi
 #include "GaudiKernel/IEventProcessor.h"
 #include "GaudiKernel/IIncidentSvc.h"
@@ -9,6 +11,7 @@
 #include "GaudiKernel/StatusCode.h"
 
 // Datamodel
+#include "edm4hep/Constants.h"
 #include "edm4hep/MCParticleCollection.h"
 
 // ROOT

--- a/k4Gen/src/components/GenEventFilter.cpp
+++ b/k4Gen/src/components/GenEventFilter.cpp
@@ -2,6 +2,7 @@
 
 // Gaudi
 #include "GaudiKernel/IEventProcessor.h"
+#include "GaudiKernel/IIncidentSvc.h"
 #include "GaudiKernel/ISvcLocator.h"
 #include "GaudiKernel/Incident.h"
 #include "GaudiKernel/MsgStream.h"
@@ -162,7 +163,8 @@ StatusCode GenEventFilter::execute(const EventContext&) const {
 StatusCode GenEventFilter::finalize() {
   debug() << "Number of events seen: " << m_nEventsSeen << endmsg;
 
-  m_evtFilterStats.put({m_nEventsSeen, m_nEventsAccepted, m_nEventsTarget});
+  k4FWCore::putParameter(edm4hep::labels::EventFilterStats,
+                         std::vector<int>{m_nEventsSeen, m_nEventsAccepted, m_nEventsTarget}, this);
 
   return Gaudi::Algorithm::finalize();
 }

--- a/k4Gen/src/components/GenEventFilter.h
+++ b/k4Gen/src/components/GenEventFilter.h
@@ -9,10 +9,8 @@ class IEventProcessor;
 
 // k4FWCore
 #include "k4FWCore/DataHandle.h"
-#include "k4FWCore/MetadataUtils.h"
 
 // Datamodel
-#include "edm4hep/Constants.h"
 #include "edm4hep/MCParticleCollection.h"
 
 /** @class GenEventFilter Generation/src/components/GenEventFilter.h GenEventFilter.h

--- a/k4Gen/src/components/GenEventFilter.h
+++ b/k4Gen/src/components/GenEventFilter.h
@@ -9,7 +9,7 @@ class IEventProcessor;
 
 // k4FWCore
 #include "k4FWCore/DataHandle.h"
-#include "k4FWCore/MetaDataHandle.h"
+#include "k4FWCore/MetadataUtils.h"
 
 // Datamodel
 #include "edm4hep/Constants.h"
@@ -38,8 +38,6 @@ public:
 private:
   /// Handle for the MCParticle collection to be read.
   mutable k4FWCore::DataHandle<edm4hep::MCParticleCollection> m_inColl{"particles", Gaudi::DataHandle::Reader, this};
-  /// Writes out filter statistics.
-  k4FWCore::MetaDataHandle<std::vector<int>> m_evtFilterStats{edm4hep::labels::EventFilterStats, Gaudi::DataHandle::Writer};
 
   /// Rule to filter the events with.
   Gaudi::Property<std::string> m_filterRuleStr{this, "filterRule", "", "Filter rule to apply on the events"};


### PR DESCRIPTION
BEGINRELEASENOTES
- Use the metadata utilities from k4FWCore instead of MetaDataHandle

ENDRELEASENOTES

The MetaDataHandle uses the deprecated `PodioDataSvc` but it doesn't throw any warnings.