### PR TITLE
add event headers to pythia and particle gun examples

### DIFF
--- a/k4Gen/options/particleGun.py
+++ b/k4Gen/options/particleGun.py
@@ -10,6 +10,13 @@ ApplicationMgr(
                ExtSvc=[EventDataSvc("EventDataSvc")],
               )
 
+from Configurables import EventHeaderCreator
+eventHeaderCreator = EventHeaderCreator(
+    "eventHeaderCreator", runNumber=42, eventNumberOffset=42
+)
+ApplicationMgr().TopAlg += [eventHeaderCreator]
+
+
 from edm4hep import labels as e4_labels
 
 from Configurables import ConstPtParticleGun

--- a/k4Gen/options/pythia.py
+++ b/k4Gen/options/pythia.py
@@ -17,6 +17,13 @@ ApplicationMgr().EvtMax = 2
 ApplicationMgr().OutputLevel = INFO
 ApplicationMgr().ExtSvc += ["RndmGenSvc", EventDataSvc("EventDataSvc")]
 
+from Configurables import EventHeaderCreator
+eventHeaderCreator = EventHeaderCreator(
+    "eventHeaderCreator", runNumber=42, eventNumberOffset=42
+)
+ApplicationMgr().TopAlg += [eventHeaderCreator]
+
+
 from Configurables import GaussSmearVertex
 smeartool = GaussSmearVertex()
 smeartool.xVertexSigma =   0.5*units.mm

--- a/k4Gen/options/pythiaEventsFiltered.py
+++ b/k4Gen/options/pythiaEventsFiltered.py
@@ -24,6 +24,13 @@ ApplicationMgr().ExtSvc += ["RndmGenSvc"]
 
 ApplicationMgr().ExtSvc += [EventDataSvc("EventDataSvc")]
 
+from Configurables import EventHeaderCreator
+eventHeaderCreator = EventHeaderCreator(
+    "eventHeaderCreator", runNumber=42, eventNumberOffset=42
+)
+ApplicationMgr().TopAlg += [eventHeaderCreator]
+
+
 smeartool = GaussSmearVertex()
 smeartool.xVertexSigma = 0.5 * units.mm
 smeartool.yVertexSigma = 0.5 * units.mm


### PR DESCRIPTION
Add event headers to each of the examples for pythia and particle gun generation. It appears that pythiaEventsFiltered.py is not working currently. I propose to investigate that as a separate PR.

BEGINRELEASENOTES
Add event headers to each of the examples for pythia and particle gun generation
ENDRELEASENOTES
